### PR TITLE
 Feat/60 UI for admin manage accounts page

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,84 +1,100 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
-import './index.css'
-import App from './App.tsx'
-import { Layout } from './components/layout/AppLayout.tsx'
-import { AdminDashboard } from './components/dashboard/AdminDashboard'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  createBrowserRouter,
+  Navigate,
+  RouterProvider,
+} from "react-router-dom";
+import "./index.css";
+import App from "./App.tsx";
+import { Layout } from "./components/layout/AppLayout.tsx";
+import ManageAccountsPage from "./manage-accounts/ManageAccountsPage.tsx";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <Layout />,
     handle: {
-      crumb: { title: "Home" }
+      crumb: { title: "Home" },
     },
     children: [
       {
         index: true,
-        element: <Navigate to="/home" replace />
+        element: <Navigate to="/home" replace />,
       },
       {
         path: "home",
-        element: <div>Home Page</div>,        // TO BE REPLACED
+        element: <div>Home Page</div>, // TO BE REPLACED
         handle: {
-          crumb: { title: "Home Page" }
-        }
+          crumb: { title: "Home Page" },
+        },
       },
       {
         path: "algotime",
-        element: <div>AlgoTime</div>,        // TO BE REPLACED
+        element: <div>AlgoTime</div>, // TO BE REPLACED
         handle: {
-          crumb: { title: "AlgoTime" }
-        }
+          crumb: { title: "AlgoTime" },
+        },
       },
       {
         path: "competition",
-        element: <div>Competition</div>,        // TO BE REPLACED
+        element: <div>Competition</div>, // TO BE REPLACED
         handle: {
-          crumb: { title: "Competition" }
-        }
+          crumb: { title: "Competition" },
+        },
       },
       {
         path: "settings",
-        element: <div>Settings</div>,        // TO BE REPLACED
+        element: <div>Settings</div>, // TO BE REPLACED
         handle: {
-          crumb: { title: "Settings" }
-        }
+          crumb: { title: "Settings" },
+        },
       },
       {
         path: "leaderboards",
         handle: {
-          crumb: { title: "Leaderboards" }
+          crumb: { title: "Leaderboards" },
         },
         children: [
           {
             index: true,
-            element: <div>Competitions</div>,        // TO BE REPLACED
+            element: <div>Competitions</div>, // TO BE REPLACED
           },
           {
             path: ":competitionId",
-            element: <div>Competition Leaderboard</div>,        // TO BE REPLACED
+            element: <div>Competition Leaderboard</div>, // TO BE REPLACED
             handle: {
-              crumb: { title: "Competition Leaderboard" }
-            }
-          }
-        ]
+              crumb: { title: "Competition Leaderboard" },
+            },
+          },
+        ],
       },
       {
         path: "dashboard",
-        element: <AdminDashboard />,        
+        element: <div>Admin Dashboard</div>, // TO BE REPLACED
         handle: {
-          crumb: { title: "Admin Dashboard" }
-        }
+          crumb: { title: "Admin Dashboard" },
+        },
       },
-    ]
+      {
+        path: "manage-accounts",
+        element: (
+          <div>
+            Admin Dashboard
+            <ManageAccountsPage />
+          </div>
+        ), // TO BE REPLACED
+        handle: {
+          crumb: { title: "Manage Accounts" },
+        },
+      },
+    ],
   },
-])
+]);
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
     <RouterProvider router={router} />
-  </StrictMode>,
-)
+  </StrictMode>
+);


### PR DESCRIPTION
## 📝 Description

> Reopened the issue 60 PR to add the manage account page to the router.

## 🔧 Changes Made

List all major updates or modifications:

- Added the manage-accounts folder and the files within this folder
- created the ManageAccountsColumns file where the columns for the table are defined
- created the ManageAccountsDataTable file where the table component is created
- created the ManageAccountsPage file where the data will be sent to from the server and to render the component (though right now it is using hardcoded data)
- Also refactored the color for the primary value in the index.css file so that using primary keyword in our components automatically uses the default purple

## 🎯 Related Issues

Closes #60 

## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ]  I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)
<img width="1919" height="1142" alt="image" src="https://github.com/user-attachments/assets/e3731d5e-02e4-4514-96cf-5e549c56d42d" />

## 💬 Additional Notes

Any extra context, caveats, or follow-up tasks:
This is part of issue #21. Only takes care of the frontend part as the backend is still a work in progress.
