### PR TITLE
Add Supabase environment variables to CI pipeline

### DIFF
--- a/.github/workflows/CI_Pipeline.yml
+++ b/.github/workflows/CI_Pipeline.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           PYTHONPATH: .
           BREVO_API_KEY: test-brevo-key
+          SUPABASE_URL: https://DEW.supabase.co/
+          SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJp
           DEFAULT_SENDER_EMAIL: test@example.com
           DATABASE_URL: "sqlite+pysqlite:///:memory:"
         run: pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
Added mocked var to env of CI/CD

## 📝 Description

> This PR adds dummy/fake environment variables for the CI/CD pipeline. These placeholders allow the automated test suite to initialize and run without requiring access to real production secrets or a local `.env` file.

## 🔧 Changes Made

- **Added** fake environment variables (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, etc.) to the CI/CD configuration.
- **Fixed** pipeline failures caused by missing environment variables during the initialization of the Supabase client in tests.

## 🎯 Related Issues

- Related to CI/CD pipeline stabilization.

## ✅ Checklist

- [x] My code follows the project’s style guidelines
- [x] I’ve performed a self-review of my own code
- [x] I’ve removed unnecessary commented out code
- [x] I’ve added or updated tests if applicable
- [x] New and existing tests pass locally

## 💬 Additional Notes

- These variables are strictly for the CI environment to bypass connection checks.
- No real credentials have been exposed.
