### PR TITLE
Fix login page

### DIFF
--- a/frontend/src/components/forms/SignupForm.tsx
+++ b/frontend/src/components/forms/SignupForm.tsx
@@ -103,6 +103,11 @@ export function SignupForm() {
     e.preventDefault();
     setError(null);
 
+    if (formData.password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+
     if (formData.password !== formData.confirm_password) {
       setError("Passwords do not match");
       return;
@@ -204,12 +209,19 @@ export function SignupForm() {
           <Input
             id="password"
             type="password"
+            placeholder="At least 8 characters"
             value={formData.password}
             onChange={(e) =>
               setFormData({ ...formData, password: e.target.value })
             }
+            className={`h-10 focus-visible:ring-primary focus-visible:ring-1 ${formData.password && formData.password.length < 8 ? "border-red-500 focus-visible:ring-red-500" : ""}`}
             required
           />
+          {formData.password && formData.password.length < 8 && (
+            <p className="text-red-500 text-xs font-medium mt-1">
+              Password must be at least 8 characters
+            </p>
+          )}
         </Field>
 
         <Field>
@@ -223,8 +235,14 @@ export function SignupForm() {
             onChange={(e) =>
               setFormData({ ...formData, confirm_password: e.target.value })
             }
+            className={`h-10 focus-visible:ring-primary focus-visible:ring-1 ${formData.confirm_password && formData.password !== formData.confirm_password ? "border-red-500 focus-visible:ring-red-500" : ""}`}
             required
           />
+          {formData.confirm_password && formData.password !== formData.confirm_password && (
+            <p className="text-red-500 text-xs font-medium mt-1">
+              Passwords do not match
+            </p>
+          )}
         </Field>
 
         {error && <p className="text-red-500 text-sm text-center">{error}</p>}

--- a/frontend/src/views/ChangePasswordPage.tsx
+++ b/frontend/src/views/ChangePasswordPage.tsx
@@ -130,9 +130,14 @@ function ChangePasswordPage() {
                   placeholder="At least 8 characters"
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
-                  className="h-10 focus-visible:ring-primary focus-visible:ring-1"
+                  className={`h-10 focus-visible:ring-primary focus-visible:ring-1 ${newPassword && newPassword.length < 8 ? "border-red-500 focus-visible:ring-red-500" : ""}`}
                   disabled={isSubmitting}
                 />
+                {newPassword && newPassword.length < 8 && (
+                  <p className="text-xs text-red-500 font-medium ml-1">
+                    Password must be at least 8 characters
+                  </p>
+                )}
               </div>
 
               {/* Confirm New Password */}

--- a/frontend/tests/SignupForm.test.tsx
+++ b/frontend/tests/SignupForm.test.tsx
@@ -27,6 +27,16 @@ jest.mock("@/api/LoggerAPI", () => ({
     logFrontend: jest.fn(),
 }));
 
+// Mock useAnalytics hook
+jest.mock("@/hooks/useAnalytics", () => ({
+    useAnalytics: () => ({
+        identifyUser: jest.fn(),
+        trackSignupAttempt: jest.fn(),
+        trackSignupSuccess: jest.fn(),
+        trackSignupFailed: jest.fn(),
+    }),
+}));
+
 // Mock react-router-dom
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({
@@ -208,10 +218,72 @@ describe("SignupForm", () => {
             fireEvent.click(submitButton);
 
             await waitFor(() => {
-                expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+                // Both live validation and form error show "Passwords do not match"
+                const errorMessages = screen.getAllByText("Passwords do not match");
+                expect(errorMessages.length).toBeGreaterThanOrEqual(1);
             });
 
             expect(mockSignup).not.toHaveBeenCalled();
+        });
+
+        test("shows error when password is less than 8 characters", async () => {
+            render(<SignupForm />);
+
+            const firstNameInput = screen.getByLabelText("First Name");
+            const lastNameInput = screen.getByLabelText("Last Name");
+            const emailInput = screen.getByLabelText("Email");
+            const passwordInput = screen.getByLabelText(/^Password$/);
+            const confirmPasswordInput = screen.getByLabelText("Confirm Password");
+            const submitButton = screen.getByRole("button", { name: /create account/i });
+
+            fireEvent.change(firstNameInput, { target: { value: "John" } });
+            fireEvent.change(lastNameInput, { target: { value: "Doe" } });
+            fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+            fireEvent.change(passwordInput, { target: { value: "short" } });
+            fireEvent.change(confirmPasswordInput, { target: { value: "short" } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => {
+                // Both live validation and form error show the message
+                const errorMessages = screen.getAllByText("Password must be at least 8 characters");
+                expect(errorMessages.length).toBeGreaterThanOrEqual(1);
+            });
+
+            expect(mockSignup).not.toHaveBeenCalled();
+        });
+
+        test("shows live validation message when typing short password", async () => {
+            render(<SignupForm />);
+
+            const passwordInput = screen.getByLabelText(/^Password$/);
+            fireEvent.change(passwordInput, { target: { value: "short" } });
+
+            expect(screen.getByText("Password must be at least 8 characters")).toBeInTheDocument();
+        });
+
+        test("hides live validation message when password reaches 8 characters", async () => {
+            render(<SignupForm />);
+
+            const passwordInput = screen.getByLabelText(/^Password$/);
+
+            fireEvent.change(passwordInput, { target: { value: "short" } });
+            expect(screen.getByText("Password must be at least 8 characters")).toBeInTheDocument();
+
+            fireEvent.change(passwordInput, { target: { value: "longenough" } });
+            expect(screen.queryByText("Password must be at least 8 characters")).not.toBeInTheDocument();
+        });
+
+        test("shows live validation when confirm password does not match", async () => {
+            render(<SignupForm />);
+
+            const passwordInput = screen.getByLabelText(/^Password$/);
+            const confirmPasswordInput = screen.getByLabelText("Confirm Password");
+
+            fireEvent.change(passwordInput, { target: { value: "password123" } });
+            fireEvent.change(confirmPasswordInput, { target: { value: "different" } });
+
+            expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
         });
 
         test("does not show error when passwords match", async () => {


### PR DESCRIPTION
## 📝 Description

> This PR adds consistent password validation behavior between the signup form and change password page. 

## 🔧 Changes Made

- Added 8-character minimum password validation to signup form
- Fixed inconsistent password requirements between signup and change password flows
- Added live validation messages below password fields that appear in red while typing:                                                   "Password must be at least 8 characters" /"Passwords do not match"

## 🎯 Related Issues

Closes #224 

## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ]  I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

<img width="347" height="652" alt="image" src="https://github.com/user-attachments/assets/08173f5d-2dcd-40c2-876e-5e16e45183fe" />
<img width="353" height="666" alt="image" src="https://github.com/user-attachments/assets/43b02f09-1ea3-4422-b7e8-9cfeb7bb6fc1" />
<img width="599" height="410" alt="image" src="https://github.com/user-attachments/assets/d524d60e-5463-4220-b7cc-ea22e1fbd346" />
<img width="526" height="344" alt="image" src="https://github.com/user-attachments/assets/9170eb1a-5d7a-4539-a167-cbdb64b4a04c" />

## 💬 Additional Notes

none
