### PR TITLE
load per-language preset code in coding editor

### DIFF
--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -269,6 +269,8 @@ const CodingView = () => {
   const [selectedLang, setSelectedLang] = useState<SupportedLanguagesType>("Java")
   // Keep a ref to the previous language so we can log "from → to" on change
   const prevLangRef = useRef<SupportedLanguagesType>("Java")
+  // Per-language code buffers — key: `${questionId}_${lang}`, value: user's typed code
+  const codeBuffersRef = useRef<Map<string, string>>(new Map())
 
   // Look up the DB-stored properties for the currently selected language
   const activeLangProps = useMemo(
@@ -293,9 +295,15 @@ const CodingView = () => {
 
   const [code, setCode] = useState<string>('')
 
-  // Reset editor on language change or question change
-  useEffect(() => { setCode(presetCode) }, [selectedLang]) // eslint-disable-line react-hooks/exhaustive-deps
-  useEffect(() => { setCode(presetCode) }, [activeQuestion?.question_id]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Restore buffer or fall back to presetCode on language/question change
+  useEffect(() => {
+    const saved = codeBuffersRef.current.get(`${activeQuestion?.question_id}_${selectedLang}`)
+    setCode(saved ?? presetCode)
+  }, [selectedLang]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const saved = codeBuffersRef.current.get(`${activeQuestion?.question_id}_${selectedLang}`)
+    setCode(saved ?? presetCode)
+  }, [activeQuestion?.question_id]) // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (mostRecentSub) {
       setMostRecentSubGroupClass("grid grid-cols-3 gap-2")
@@ -306,9 +314,11 @@ const CodingView = () => {
 
   const handleLanguageChange = (lang: SupportedLanguagesType) => {
     trackLanguageChanged(activeQuestion?.question_id, prevLangRef.current, lang)
+    // Save current code before switching so user can come back to it
+    codeBuffersRef.current.set(`${activeQuestion?.question_id}_${selectedLang}`, code)
     prevLangRef.current = lang
     setSelectedLang(lang)
-    setCode(presetCode)
+    // useEffect on selectedLang will restore buffer or fall back to presetCode
   }
 
   const handleQuestionChange = (q: Question) => {
@@ -323,6 +333,8 @@ const CodingView = () => {
 
   const handleCodeReset = () => {
     trackCodeReset(activeQuestion?.question_id, selectedLang)
+    // Clear buffer so switching away and back also resets
+    codeBuffersRef.current.delete(`${activeQuestion?.question_id}_${selectedLang}`)
     setCode(presetCode)
   }
 

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -313,7 +313,7 @@ const CodingView = () => {
   }, [mostRecentSub])
 
   const handleLanguageChange = (lang: SupportedLanguagesType) => {
-    trackLanguageChanged(activeQuestion?.question_id, prevLangRef.current, lang)
+    trackLanguageChanged(activeQuestion!.question_id, prevLangRef.current, lang)
     // Save current code before switching so user can come back to it
     codeBuffersRef.current.set(`${activeQuestion?.question_id}_${selectedLang}`, code)
     prevLangRef.current = lang
@@ -332,7 +332,7 @@ const CodingView = () => {
   }
 
   const handleCodeReset = () => {
-    trackCodeReset(activeQuestion?.question_id, selectedLang)
+    trackCodeReset(activeQuestion!.question_id, selectedLang)
     // Clear buffer so switching away and back also resets
     codeBuffersRef.current.delete(`${activeQuestion?.question_id}_${selectedLang}`)
     setCode(presetCode)

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -293,8 +293,9 @@ const CodingView = () => {
 
   const [code, setCode] = useState<string>('')
 
-  // Reset editor on language change
+  // Reset editor on language change or question change
   useEffect(() => { setCode(presetCode) }, [selectedLang]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { setCode(presetCode) }, [activeQuestion?.question_id]) // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (mostRecentSub) {
       setMostRecentSubGroupClass("grid grid-cols-3 gap-2")

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -288,10 +288,13 @@ const CodingView = () => {
     outputType: "number[]",
   });
 
+  // Priority: DB preset_code → DB template_solution → hardcoded fallback
+  const presetCode = activeLangProps?.preset_code || activeLangProps?.template_solution || templateCode
+
   const [code, setCode] = useState<string>('')
 
   // Reset editor on language change
-  useEffect(() => { setCode(templateCode) }, [selectedLang]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { setCode(presetCode) }, [selectedLang]) // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (mostRecentSub) {
       setMostRecentSubGroupClass("grid grid-cols-3 gap-2")
@@ -304,7 +307,7 @@ const CodingView = () => {
     trackLanguageChanged(activeQuestion?.question_id, prevLangRef.current, lang)
     prevLangRef.current = lang
     setSelectedLang(lang)
-    setCode(templateCode)
+    setCode(presetCode)
   }
 
   const handleQuestionChange = (q: Question) => {
@@ -319,7 +322,7 @@ const CodingView = () => {
 
   const handleCodeReset = () => {
     trackCodeReset(activeQuestion?.question_id, selectedLang)
-    setCode(templateCode)
+    setCode(presetCode)
   }
 
   const [fullCode, setFullCode] = useState(false)

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import CodeDescArea from "../components/codingPage/CodeDescArea";
 import {
   Play, RotateCcw, Maximize2, ChevronDown,
@@ -269,6 +269,14 @@ const CodingView = () => {
   const [selectedLang, setSelectedLang] = useState<SupportedLanguagesType>("Java")
   // Keep a ref to the previous language so we can log "from → to" on change
   const prevLangRef = useRef<SupportedLanguagesType>("Java")
+
+  // Look up the DB-stored properties for the currently selected language
+  const activeLangProps = useMemo(
+    () => activeQuestion?.language_specific_properties.find(
+      (p) => p.language_name === selectedLang
+    ) ?? null,
+    [activeQuestion, selectedLang]
+  )
 
   const { language, judgeID, templateCode } = buildMonacoCode({
     language: selectedLang,

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -112,10 +112,12 @@ const CodingView = () => {
       const initQuestion = async () => {
         setIsQuestionLoading(true)
         try {
-          await getQuestionInstance(question?.question_id, null)
-            .then((response) => {
-              setQuestionsInstances([response])
-            })
+          const [questionInstance, fullQuestion] = await Promise.all([
+            getQuestionInstance(question.question_id, null),
+            getQuestionByID(question.question_id),
+          ])
+          setQuestionsInstances([questionInstance])
+          setQuestions([fullQuestion])
         } catch (err) {
           toast.error("Error when fetching question instance.")
           logFrontend({
@@ -130,7 +132,6 @@ const CodingView = () => {
         }
       }
       initQuestion()
-      setQuestions([question])
     }
   }, [event, question?.question_id])
 

--- a/frontend/tests/CodingView.test.tsx
+++ b/frontend/tests/CodingView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import '@testing-library/jest-dom'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import CodingView from '../src/views/CodingView'
 import { useLocation } from 'react-router-dom'
@@ -145,6 +145,17 @@ jest.mock("../src/components/ui/dropdown-menu", () => {
     }
 })
 
+// Map onSelect → onClick so language items are clickable in tests
+jest.mock('@radix-ui/react-dropdown-menu', () => ({
+    __esModule: true,
+    DropdownMenu: ({ children }: any) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+    DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+    DropdownMenuItem: ({ children, onSelect, ...rest }: any) => (
+        <div onClick={onSelect} {...rest}>{children}</div>
+    ),
+}))
+
 jest.mock("react-resizable-panels", () => ({
     __esModule: true,
     PanelGroup: React.forwardRef(({ children }: any, ref) => {
@@ -162,16 +173,9 @@ jest.mock("react-resizable-panels", () => ({
 jest.mock("../src/components/helpers/monacoConfig", () => ({
     __esModule: true,
     buildMonacoCode: jest.fn(() => ({
-        Javascript: {
-            monacoID: "javascript",
-            judgeID: "63",
-            templateCode: "console.log('test javascript')",
-        },
-        Typescript: {
-            monacoID: "typescript",
-            judgeID: "74",
-            templateCode: "console.log('test typescript')",
-        },
+        language: "java",
+        judgeID: "62",
+        templateCode: "// default template",
     })),
 }))
 
@@ -182,6 +186,7 @@ const mockedLogger = logFrontend as jest.Mock
 const mockedSubmitToJudge0 = submitToJudge0 as jest.MockedFunction<typeof submitToJudge0>
 const mockedSubmitAttempt = submitAttempt as jest.MockedFunction<typeof submitAttempt>
 const mockedGetQuestionInstance = getQuestionInstance as jest.MockedFunction<typeof getQuestionInstance>
+const mockedGetQuestionByID = getQuestionByID as jest.MockedFunction<typeof getQuestionByID>
 const mockedGetProfile = getProfile as jest.MockedFunction<typeof getProfile>
 
 const mockProblem: Question = {
@@ -195,6 +200,45 @@ const mockProblem: Question = {
     testcases: [],
     created_at: new Date("2025-10-28T10:00:00Z"),
     last_modified_at: new Date("2025-10-28T10:00:00Z"),
+}
+
+const mockProblemWithPreset: Question = {
+    ...mockProblem,
+    language_specific_properties: [
+        {
+            language_id: 1,
+            question_id: 1,
+            language_name: "Java",
+            preset_code: "// Java preset",
+            template_solution: "// Java solution",
+            from_json_function: "",
+            to_json_function: "",
+        },
+        {
+            language_id: 2,
+            question_id: 1,
+            language_name: "Python",
+            preset_code: "# Python preset",
+            template_solution: "# Python solution",
+            from_json_function: "",
+            to_json_function: "",
+        },
+    ],
+}
+
+const mockProblemWithTemplateSolutionOnly: Question = {
+    ...mockProblem,
+    language_specific_properties: [
+        {
+            language_id: 1,
+            question_id: 1,
+            language_name: "Java",
+            preset_code: "",
+            template_solution: "// Java solution fallback",
+            from_json_function: "",
+            to_json_function: "",
+        },
+    ],
 }
 
 const mockUseTestcases = useTestcases as jest.Mock
@@ -320,11 +364,12 @@ describe('CodingView Component without event', () => {
             activeTestcase: 'Case 1',
             setActiveTestcase,
         })
+
+        mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
+        mockedGetQuestionByID.mockResolvedValue(mockProblem)
     })
 
     it('renders and shows key panels (resizable panels and sandbox tabs)', async () => {
-        mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
-
         render(<CodingView />)
 
         await waitFor(() => {
@@ -485,7 +530,6 @@ describe('CodingView Component without event', () => {
 
     it('execute code and updates logs when run button is clicked', async () => {
         mockedSubmitToJudge0.mockResolvedValueOnce(mockCodeRunResponse)
-        mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
         mockedGetProfile.mockResolvedValue(mockProfile)
 
         render(<CodingView />)
@@ -525,9 +569,7 @@ describe('CodingView Component without event', () => {
 
     it('handles async loading state during code execution', async () => {
         mockedSubmitToJudge0.mockResolvedValueOnce(mockCodeRunResponse)
-        mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
         mockedGetProfile.mockResolvedValue(mockProfile)
-        // mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
 
         render(<CodingView />)
 
@@ -599,5 +641,125 @@ describe('CodingView Component without event', () => {
         render(<CodingView />)
 
         expect(screen.getByTestId('Loader')).toBeInTheDocument()
+    })
+
+    // --- Preset code feature tests ---
+
+    it('loads preset_code from DB into editor when question has language_specific_properties', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
+
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
+    })
+
+    it('falls back to template_solution when preset_code is empty', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblemWithTemplateSolutionOnly)
+
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java solution fallback')
+        })
+    })
+
+    it('falls back to hardcoded template when no language_specific_properties match', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblem) // language_specific_properties: []
+
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// default template')
+        })
+    })
+
+    it('fetches full question data (getQuestionByID) on practice mode load', async () => {
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(mockedGetQuestionByID).toHaveBeenCalledWith(mockProblem.question_id)
+        })
+    })
+
+    it('shows preset_code of new language after switching', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
+
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
+
+        fireEvent.click(screen.getByTestId('languageItem-Python'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('# Python preset')
+        })
+    })
+
+    it('preserves typed code in buffer when switching languages and restores it on switch back', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
+
+        render(<CodingView />)
+
+        // Wait for Java preset to load
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
+
+        // User types custom Java code
+        const editor = screen.getByTestId('monaco-editor')
+        await userEvent.clear(editor)
+        await userEvent.type(editor, 'my custom java code')
+        expect(editor).toHaveValue('my custom java code')
+
+        // Switch to Python — Java code should be saved to buffer
+        fireEvent.click(screen.getByTestId('languageItem-Python'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('# Python preset')
+        })
+
+        // Switch back to Java — buffer should restore custom code
+        fireEvent.click(screen.getByTestId('languageItem-Java'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('my custom java code')
+        })
+    })
+
+    it('reset button restores preset_code and clears buffer', async () => {
+        mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
+
+        render(<CodingView />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
+
+        // User types custom code
+        const editor = screen.getByTestId('monaco-editor')
+        await userEvent.clear(editor)
+        await userEvent.type(editor, 'my custom java code')
+
+        // Click reset — should restore preset
+        const codingBtns = screen.getByTestId('coding-btns')
+        const buttons = within(codingBtns).getAllByRole('button')
+        const resetBtn = buttons[1] // play=0, reset=1
+        await userEvent.click(resetBtn)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
+
+        // Switch away and back — buffer was cleared so preset should still show
+        fireEvent.click(screen.getByTestId('languageItem-Python'))
+        fireEvent.click(screen.getByTestId('languageItem-Java'))
+
+        await waitFor(() => {
+            expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
+        })
     })
 })

--- a/frontend/tests/CodingView.test.tsx
+++ b/frontend/tests/CodingView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import '@testing-library/jest-dom'
-import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import CodingView from '../src/views/CodingView'
 import { useLocation } from 'react-router-dom'
@@ -17,12 +17,8 @@ import { submitAttempt } from '../src/api/CodeSubmissionAPI'
 import { getProfile } from '../src/api/AuthAPI'
 import { toast } from 'sonner'
 import { logFrontend } from "../src/api/LoggerAPI"
-import { getQuestionInstance, getAllQuestionInstancesByEventID } from '../src/api/QuestionInstanceAPI'
-import { getQuestionByID } from '../src/api/QuestionsAPI';
-import { getEventByName } from '../src/api/BaseEventAPI';
-import { BaseEvent } from '../src/types/BaseEvent.type';
-import { describe } from 'node:test'
-
+import { getQuestionInstance } from '../src/api/QuestionInstanceAPI'
+import { getQuestionByID } from '../src/api/QuestionsAPI'
 
 jest.mock('@monaco-editor/react', () => {
     return function MonacoEditorMock(props: any) {
@@ -48,18 +44,14 @@ jest.mock('../src/lib/axiosClient', () => ({
 }))
 
 jest.mock('../src/components/helpers/Loader.tsx', () => {
-    return function Loader(props: any) {
-        return (
-            <div data-testid="Loader" />
-        )
+    return function Loader() {
+        return <div data-testid="Loader" />
     }
 })
 
 jest.mock('../src/components/codingPage/ConsoleOutput.tsx', () => {
-    return function ConsoleOutput(props: any) {
-        return (
-            <div data-testid="ConsoleOutput" />
-        )
+    return function ConsoleOutput() {
+        return <div data-testid="ConsoleOutput" />
     }
 })
 
@@ -127,11 +119,7 @@ jest.mock('../src/components/codingPage/Testcases', () => ({
 
 jest.mock("../src/components/ui/dropdown-menu", () => {
     const React = require('react')
-
-    const DropdownContext = React.createContext({
-        itemMap: new Map(),
-    })
-
+    const DropdownContext = React.createContext({ itemMap: new Map() })
     return {
         __esModule: true,
         DropdownMenu: ({ children }: any) => (
@@ -145,7 +133,7 @@ jest.mock("../src/components/ui/dropdown-menu", () => {
     }
 })
 
-// Map onSelect → onClick so language items are clickable in tests
+// Map onSelect → onClick so language/question items can be triggered in tests
 jest.mock('@radix-ui/react-dropdown-menu', () => ({
     __esModule: true,
     DropdownMenu: ({ children }: any) => <div>{children}</div>,
@@ -159,14 +147,10 @@ jest.mock('@radix-ui/react-dropdown-menu', () => ({
 jest.mock("react-resizable-panels", () => ({
     __esModule: true,
     PanelGroup: React.forwardRef(({ children }: any, ref) => {
-        React.useImperativeHandle(ref, () => ({
-            setLayout: jest.fn(),
-        }))
-        return <div data-testid="panel-group" >{children}</div>
+        React.useImperativeHandle(ref, () => ({ setLayout: jest.fn() }))
+        return <div data-testid="panel-group">{children}</div>
     }),
-    Panel: ({ children }: any) => (
-        <div data-testid="resizable-panel" >{children}</div>
-    ),
+    Panel: ({ children }: any) => <div data-testid="resizable-panel">{children}</div>,
     PanelResizeHandle: () => <div data-testid="resizable-handle" />,
 }))
 
@@ -181,13 +165,12 @@ jest.mock("../src/components/helpers/monacoConfig", () => ({
 
 jest.mock('../src/components/helpers/useTestcases')
 
-const mockedToast = toast as jest.Mocked<typeof toast>
-const mockedLogger = logFrontend as jest.Mock
 const mockedSubmitToJudge0 = submitToJudge0 as jest.MockedFunction<typeof submitToJudge0>
 const mockedSubmitAttempt = submitAttempt as jest.MockedFunction<typeof submitAttempt>
 const mockedGetQuestionInstance = getQuestionInstance as jest.MockedFunction<typeof getQuestionInstance>
 const mockedGetQuestionByID = getQuestionByID as jest.MockedFunction<typeof getQuestionByID>
 const mockedGetProfile = getProfile as jest.MockedFunction<typeof getProfile>
+const mockUseTestcases = useTestcases as jest.Mock
 
 const mockProblem: Question = {
     question_id: 1,
@@ -241,25 +224,13 @@ const mockProblemWithTemplateSolutionOnly: Question = {
     ],
 }
 
-const mockUseTestcases = useTestcases as jest.Mock
+const mockTestcases = [{ caseID: 'Case 1', input_data: { a: 10, b: 20 } }]
 
-const mockTestcases = [
-    {
-        caseID: 'Case 1',
-        input_data: {
-            a: 10,
-            b: 20,
-        },
-    },
-]
-
-const question_id = 1
-const question_instance_id = 123
 const user_id = 1
+const question_instance_id = 123
 const event_id = 1
 const source_code = "print('Hello')"
 const language_id = "71"
-
 
 const mockProfile: Account = {
     id: user_id,
@@ -267,17 +238,6 @@ const mockProfile: Account = {
     lastName: "string",
     email: "string@smt.com",
     accountType: "Participant"
-}
-
-const mockEvent: BaseEvent = {
-    event_id: event_id,
-    event_name: 'Competition 10',
-    event_location: "online",
-    question_cooldown: 5,
-    event_start_date: new Date(2024, 5, 24),
-    event_end_date: new Date(2024, 5, 24),
-    created_at: new Date(2024, 5, 24),
-    updated_at: new Date(2024, 5, 24),
 }
 
 const mockMostRecentSubResponse: MostRecentSub = {
@@ -292,10 +252,7 @@ const mockJudge0Response = {
     stderr: null,
     compile_output: null,
     message: null,
-    status: {
-        id: 3,
-        description: "Accepted"
-    },
+    status: { id: 3, description: "Accepted" },
     memory: "1024",
     time: "0.123",
     token: null
@@ -317,27 +274,27 @@ const mockCodeRunResponse: CodeRunResponse = {
 
 const mockQuestionInstances: QuestionInstance[] = [{
     question_instance_id: question_instance_id,
-    question_id: question_id,
+    question_id: mockProblem.question_id,
     event_id: event_id,
     riddle_id: null,
 }]
 
 const mockSubmitAttemptResponseSUCCESS: SubmitAttemptResponse = {
     codeRunResponse: mockCodeRunResponse,
-    submissionResponse: {
-        status_code: 200,
-        message: "Submitted"
-    },
+    submissionResponse: { status_code: 200, message: "Submitted" },
     leaderboard: null
 }
 
 const mockSubmitAttemptResponseFAIL: SubmitAttemptResponse = {
     codeRunResponse: mockCodeRunResponse,
-    submissionResponse: {
-        status_code: 400,
-        message: "Failed"
-    },
+    submissionResponse: { status_code: 400, message: "Failed" },
     leaderboard: null
+}
+
+// Helper: render and wait until the question has loaded (activeQuestion is set)
+const renderAndWait = async () => {
+    render(<CodingView />)
+    await waitFor(() => expect(screen.getByTestId('sandbox')).toBeInTheDocument())
 }
 
 describe('CodingView Component without event', () => {
@@ -345,24 +302,19 @@ describe('CodingView Component without event', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
-            ; (useLocation as jest.Mock).mockReturnValue({
-                pathname: '/code/1',
-                state: { problem: mockProblem },
-            })
-
-        const addTestcase = jest.fn()
-        const removeTestcase = jest.fn()
-        const updateTestcase = jest.fn()
-        const setActiveTestcase = jest.fn()
+        ;(useLocation as jest.Mock).mockReturnValue({
+            pathname: '/code/1',
+            state: { problem: mockProblem },
+        })
 
         mockUseTestcases.mockReturnValue({
             testcases: mockTestcases,
-            addTestcase,
-            removeTestcase,
-            updateTestcase,
+            addTestcase: jest.fn(),
+            removeTestcase: jest.fn(),
+            updateTestcase: jest.fn(),
             loading: false,
             activeTestcase: 'Case 1',
-            setActiveTestcase,
+            setActiveTestcase: jest.fn(),
         })
 
         mockedGetQuestionInstance.mockResolvedValue(mockQuestionInstances[0])
@@ -370,31 +322,22 @@ describe('CodingView Component without event', () => {
     })
 
     it('renders and shows key panels (resizable panels and sandbox tabs)', async () => {
-        render(<CodingView />)
+        await renderAndWait()
 
-        await waitFor(() => {
-            expect(screen.getAllByTestId("panel-group").length).toBe(2)
-            expect(screen.getAllByTestId("resizable-panel").length).toBe(4)
-            expect(screen.getAllByTestId("resizable-handle").length).toBe(2)
-            expect(screen.getByTestId("submit-btn")).toBeInTheDocument()
-            expect(screen.getByTestId("language-btn")).toBeInTheDocument()
-            expect(screen.getByTestId("coding-btns")).toBeInTheDocument()
-            expect(screen.getByTestId("testcases-tab")).toBeInTheDocument()
-            expect(screen.getByTestId("code-output-tab")).toBeInTheDocument()
-        })
-
+        expect(screen.getAllByTestId("panel-group").length).toBe(2)
+        expect(screen.getAllByTestId("resizable-panel").length).toBe(4)
+        expect(screen.getAllByTestId("resizable-handle").length).toBe(2)
+        expect(screen.getByTestId("submit-btn")).toBeInTheDocument()
+        expect(screen.getByTestId("language-btn")).toBeInTheDocument()
+        expect(screen.getByTestId("coding-btns")).toBeInTheDocument()
+        expect(screen.getByTestId("testcases-tab")).toBeInTheDocument()
+        expect(screen.getByTestId("code-output-tab")).toBeInTheDocument()
         // questions-btn only appears when questionsInstances.length > 1
         expect(screen.queryByTestId("questions-btn")).not.toBeInTheDocument()
     })
 
-    it("doesn't call panelRef.current.resize when refs are not set", async () => {
-        render(<CodingView />)
-        fireEvent.click(screen.getByTestId('code-area-fullscreen'))
-        expect(screen.getByTestId('code-area-min-icon')).toBeInTheDocument()
-    })
-
-    it('toggles and closes code area fullscreen mode', async () => {
-        render(<CodingView />)
+    it("toggles code area to fullscreen and back", async () => {
+        await renderAndWait()
 
         expect(screen.getByTestId('code-area-max-icon')).toBeInTheDocument()
         expect(screen.queryByTestId('code-area-min-icon')).toBeNull()
@@ -403,10 +346,14 @@ describe('CodingView Component without event', () => {
 
         expect(screen.queryByTestId('code-area-max-icon')).toBeNull()
         expect(screen.getByTestId('code-area-min-icon')).toBeInTheDocument()
+
+        await userEvent.click(screen.getByTestId('code-area-fullscreen'))
+
+        expect(screen.getByTestId('code-area-max-icon')).toBeInTheDocument()
     })
 
     it('collapses and uncollapses code area', async () => {
-        render(<CodingView />)
+        await renderAndWait()
 
         expect(screen.getByTestId('code-area-up-icon')).toBeInTheDocument()
         expect(screen.queryByTestId('code-area-down-icon')).toBeNull()
@@ -417,8 +364,8 @@ describe('CodingView Component without event', () => {
         expect(screen.getByTestId('code-area-down-icon')).toBeInTheDocument()
     })
 
-    it('toggles and closes output area fullscreen mode', async () => {
-        render(<CodingView />)
+    it('toggles output area fullscreen and back', async () => {
+        await renderAndWait()
 
         expect(screen.getByTestId('output-area-max-icon')).toBeInTheDocument()
         expect(screen.queryByTestId('output-area-min-icon')).toBeNull()
@@ -430,7 +377,7 @@ describe('CodingView Component without event', () => {
     })
 
     it('collapses and uncollapses output area', async () => {
-        render(<CodingView />)
+        await renderAndWait()
 
         expect(screen.getByTestId('output-area-down-icon')).toBeInTheDocument()
         expect(screen.queryByTestId('output-area-up-icon')).toBeNull()
@@ -441,40 +388,26 @@ describe('CodingView Component without event', () => {
         expect(screen.getByTestId('output-area-up-icon')).toBeInTheDocument()
     })
 
-    it('uncollapses both areas when output area is collapsed and console is already collapsed', async () => {
-        render(<CodingView />)
-
-        expect(screen.getByTestId('code-area-up-icon')).toBeInTheDocument()
-        expect(screen.getByTestId('output-area-down-icon')).toBeInTheDocument()
-        expect(screen.queryByTestId('output-area-up-icon')).toBeNull()
-        expect(screen.queryByTestId('code-area-down-icon')).toBeNull()
+    it('uncollapses both areas when output is collapsed while code is already collapsed', async () => {
+        await renderAndWait()
 
         await userEvent.click(screen.getByTestId('output-area-collapse'))
 
         expect(screen.getByTestId('code-area-up-icon')).toBeInTheDocument()
         expect(screen.getByTestId('output-area-up-icon')).toBeInTheDocument()
-        expect(screen.queryByTestId('output-area-down-icon')).toBeNull()
-        expect(screen.queryByTestId('code-area-down-icon')).toBeNull()
     })
 
-    it('collapses both areas when console is collapsed and output area is already collapsed', async () => {
-        render(<CodingView />)
-
-        expect(screen.getByTestId('code-area-up-icon')).toBeInTheDocument()
-        expect(screen.getByTestId('output-area-down-icon')).toBeInTheDocument()
-        expect(screen.queryByTestId('output-area-up-icon')).toBeNull()
-        expect(screen.queryByTestId('code-area-down-icon')).toBeNull()
+    it('collapses both areas when code is collapsed while output is already collapsed', async () => {
+        await renderAndWait()
 
         await userEvent.click(screen.getByTestId('code-area-collapse'))
 
         expect(screen.getByTestId('code-area-down-icon')).toBeInTheDocument()
         expect(screen.getByTestId('output-area-down-icon')).toBeInTheDocument()
-        expect(screen.queryByTestId('output-area-up-icon')).toBeNull()
-        expect(screen.queryByTestId('code-area-up-icon')).toBeNull()
     })
 
     it('handles monaco editor code changes', async () => {
-        render(<CodingView />)
+        await renderAndWait()
 
         const editor = screen.getByTestId('monaco-editor')
         await userEvent.clear(editor)
@@ -487,7 +420,7 @@ describe('CodingView Component without event', () => {
         mockedSubmitAttempt.mockResolvedValue(mockSubmitAttemptResponseSUCCESS)
         mockedGetProfile.mockResolvedValue(mockProfile)
 
-        render(<CodingView />)
+        await renderAndWait()
 
         expect(screen.queryByTestId("most-recent-sub-btn")).not.toBeInTheDocument()
 
@@ -495,7 +428,6 @@ describe('CodingView Component without event', () => {
 
         expect(submitAttempt).toHaveBeenCalled()
         expect(getProfile).toHaveBeenCalled()
-
         expect(toast.success).toHaveBeenCalledWith(mockSubmitAttemptResponseSUCCESS.submissionResponse.message)
         expect(toast.warning).not.toHaveBeenCalled()
     })
@@ -504,39 +436,32 @@ describe('CodingView Component without event', () => {
         mockedSubmitAttempt.mockResolvedValue(mockSubmitAttemptResponseFAIL)
         mockedGetProfile.mockResolvedValue(mockProfile)
 
-        render(<CodingView />)
-
-        expect(screen.queryByTestId("most-recent-sub-btn")).not.toBeInTheDocument()
+        await renderAndWait()
 
         await userEvent.click(screen.getByTestId('submit-btn'))
-
-        expect(submitAttempt).toHaveBeenCalled()
-        expect(getProfile).toHaveBeenCalled()
 
         expect(toast.warning).toHaveBeenCalledWith(mockSubmitAttemptResponseFAIL.submissionResponse.message)
         expect(toast.success).not.toHaveBeenCalled()
     })
 
-    it('shows loader when question has no id', () => {
-        ; (useLocation as jest.Mock).mockReturnValue({
-            pathname: '/code/1',
-            state: { problem: { ...mockProblem, id: undefined } },
+    it('shows nothing-loaded message when no question or comp in location state', () => {
+        ;(useLocation as jest.Mock).mockReturnValue({
+            pathname: '/code',
+            state: {},
         })
 
         render(<CodingView />)
 
-        expect(screen.getByTestId('Loader')).toBeInTheDocument()
+        expect(screen.getByText(/Nothing loaded/i)).toBeInTheDocument()
     })
 
-    it('execute code and updates logs when run button is clicked', async () => {
+    it('executes code and updates logs when run button is clicked', async () => {
         mockedSubmitToJudge0.mockResolvedValueOnce(mockCodeRunResponse)
         mockedGetProfile.mockResolvedValue(mockProfile)
 
-        render(<CodingView />)
+        await renderAndWait()
 
-        const playButton = screen.getByTestId('play-btn')
-
-        await userEvent.click(playButton!)
+        await userEvent.click(screen.getByTestId('play-btn'))
 
         expect(submitToJudge0).toHaveBeenCalled()
         expect(getProfile).toHaveBeenCalled()
@@ -549,47 +474,35 @@ describe('CodingView Component without event', () => {
             .rejects.toThrow("Network error")
     })
 
-    it('handles language dropdown interaction', async () => {
-        render(<CodingView />)
-
-        const languageBtn = screen.getByTestId('language-btn')
-        expect(languageBtn).toHaveTextContent('Java')
-
-        expect(languageBtn).toBeInTheDocument()
-    })
-
-    it('handles question change', async () => {
-        render(<CodingView />)
-
-        const languageBtn = screen.getByTestId('language-btn')
-        expect(languageBtn).toHaveTextContent('Java')
-
-        expect(languageBtn).toBeInTheDocument()
-    })
-
-    it('handles async loading state during code execution', async () => {
+    it('shows loader during async code execution', async () => {
         mockedSubmitToJudge0.mockResolvedValueOnce(mockCodeRunResponse)
         mockedGetProfile.mockResolvedValue(mockProfile)
 
-        render(<CodingView />)
+        await renderAndWait()
 
-        const playButton = screen.getByTestId('play-btn')
-
-        await userEvent.click(playButton!)
+        await userEvent.click(screen.getByTestId('play-btn'))
 
         await waitFor(() => expect(screen.getByTestId('Loader')).toBeInTheDocument())
     })
 
-    it('displays coding buttons container', () => {
-        render(<CodingView />)
+    it('displays language selector defaulting to Java', async () => {
+        await renderAndWait()
+
+        const languageBtn = screen.getByTestId('language-btn')
+        expect(languageBtn).toBeInTheDocument()
+        expect(languageBtn).toHaveTextContent('Java')
+    })
+
+    it('displays coding buttons container with Code label', async () => {
+        await renderAndWait()
 
         const codingBtns = screen.getByTestId('coding-btns')
         expect(codingBtns).toBeInTheDocument()
         expect(codingBtns).toHaveTextContent('Code')
     })
 
-    it('maintains code state when changing other UI elements', async () => {
-        render(<CodingView />)
+    it('maintains typed code when toggling UI elements', async () => {
+        await renderAndWait()
 
         const editor = screen.getByTestId('monaco-editor')
         await userEvent.clear(editor)
@@ -600,31 +513,16 @@ describe('CodingView Component without event', () => {
         expect(editor).toHaveValue('test code')
     })
 
-    it('renders sandbox with correct dimensions', () => {
-        render(<CodingView />)
+    it('renders sandbox with correct CSS classes', async () => {
+        await renderAndWait()
 
         const sandbox = screen.getByTestId('sandbox')
         expect(sandbox).toBeInTheDocument()
         expect(sandbox).toHaveClass('px-2', 'h-182.5')
     })
 
-    it('displays console output tab', () => {
-        render(<CodingView />)
-
-        expect(screen.getByTestId('code-output-tab')).toBeInTheDocument()
-    })
-
-    it('handles code editor onChange with undefined value', () => {
-        render(<CodingView />)
-
-        const editor = screen.getByTestId('monaco-editor')
-        fireEvent.change(editor, { target: { value: undefined } })
-
-        expect(editor).toBeInTheDocument()
-    })
-
-    it('renders all button icons correctly', () => {
-        render(<CodingView />)
+    it('renders all panel control icons', async () => {
+        await renderAndWait()
 
         expect(screen.getByTestId('code-area-max-icon')).toBeInTheDocument()
         expect(screen.getByTestId('code-area-up-icon')).toBeInTheDocument()
@@ -632,20 +530,24 @@ describe('CodingView Component without event', () => {
         expect(screen.getByTestId('output-area-down-icon')).toBeInTheDocument()
     })
 
-    it('handles question without id', () => {
-        ; (useLocation as jest.Mock).mockReturnValue({
-            pathname: '/code/1',
-            state: { problem: { ...mockProblem, id: undefined } },
-        })
+    it('handles code editor onChange with undefined value gracefully', async () => {
+        await renderAndWait()
 
-        render(<CodingView />)
+        const editor = screen.getByTestId('monaco-editor')
+        fireEvent.change(editor, { target: { value: undefined } })
 
-        expect(screen.getByTestId('Loader')).toBeInTheDocument()
+        expect(editor).toBeInTheDocument()
+    })
+
+    it('fetches full question data via getQuestionByID on practice mode load', async () => {
+        await renderAndWait()
+
+        expect(mockedGetQuestionByID).toHaveBeenCalledWith(mockProblem.question_id)
     })
 
     // --- Preset code feature tests ---
 
-    it('loads preset_code from DB into editor when question has language_specific_properties', async () => {
+    it('loads preset_code from DB into editor', async () => {
         mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
 
         render(<CodingView />)
@@ -666,7 +568,7 @@ describe('CodingView Component without event', () => {
     })
 
     it('falls back to hardcoded template when no language_specific_properties match', async () => {
-        mockedGetQuestionByID.mockResolvedValue(mockProblem) // language_specific_properties: []
+        mockedGetQuestionByID.mockResolvedValue(mockProblem)
 
         render(<CodingView />)
 
@@ -675,15 +577,7 @@ describe('CodingView Component without event', () => {
         })
     })
 
-    it('fetches full question data (getQuestionByID) on practice mode load', async () => {
-        render(<CodingView />)
-
-        await waitFor(() => {
-            expect(mockedGetQuestionByID).toHaveBeenCalledWith(mockProblem.question_id)
-        })
-    })
-
-    it('shows preset_code of new language after switching', async () => {
+    it('shows preset_code of newly selected language after switching', async () => {
         mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
 
         render(<CodingView />)
@@ -704,12 +598,10 @@ describe('CodingView Component without event', () => {
 
         render(<CodingView />)
 
-        // Wait for Java preset to load
         await waitFor(() => {
             expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
         })
 
-        // User types custom Java code
         const editor = screen.getByTestId('monaco-editor')
         await userEvent.clear(editor)
         await userEvent.type(editor, 'my custom java code')
@@ -730,7 +622,7 @@ describe('CodingView Component without event', () => {
         })
     })
 
-    it('reset button restores preset_code and clears buffer', async () => {
+    it('reset button restores preset_code and clears the language buffer', async () => {
         mockedGetQuestionByID.mockResolvedValue(mockProblemWithPreset)
 
         render(<CodingView />)
@@ -739,7 +631,6 @@ describe('CodingView Component without event', () => {
             expect(screen.getByTestId('monaco-editor')).toHaveValue('// Java preset')
         })
 
-        // User types custom code
         const editor = screen.getByTestId('monaco-editor')
         await userEvent.clear(editor)
         await userEvent.type(editor, 'my custom java code')


### PR DESCRIPTION
## 📝 Description

>  Previously, the coding editor always loaded a hardcoded template when opening a question or switching languages, also  switching languages would wipe whatever the user had typed.                                                                            
This PR adds support for per-language preset code on the coding page, the editor now loads starter code from the      database when available, and preserves the user's code across language switches.

## 🔧 Changes Made

- Added preset code per language loaded from DB                                                                        
- Added activeLangProps lookup for DB language properties                                                              
- Added code buffer to preserve user's code when switching languages                                                   
- Added editor reset on question change                                                                                
- Fixed partial question data on practice mode  

## 🎯 Related Issues

Closes #285 

## ✅ Checklist

Before requesting review, confirm the following:

 - [x] My code follows the project’s style guidelines
 - [x] I’ve performed a self-review of my own code
 - [x] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [x]  I’ve added or updated tests if applicable
 - [x] New and existing tests pass locally
 - [x] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

<img width="1338" height="500" alt="image" src="https://github.com/user-attachments/assets/0b4a4dc9-e76c-4c4a-b16c-a4db749b5f23" />

## 💬 Additional Notes

none
