### PR TITLE
Themes Shortcut

### DIFF
--- a/backend/tests/test_competitions_api.py
+++ b/backend/tests/test_competitions_api.py
@@ -338,9 +338,14 @@ def test_create_competition_past_date(client, mock_db):
     assert "future" in response.json()["detail"]
 
 
+@patch('src.endpoints.competitions_api.datetime')
 @patch('src.endpoints.competitions_api.send_competition_emails')
 @patch('src.endpoints.competitions_api._commit_or_rollback')
-def test_create_competition_with_email(mock_commit, mock_send_emails, client, mock_db):
+def test_create_competition_with_email(mock_commit, mock_send_emails, mock_datetime, client, mock_db):
+    mock_datetime.now.return_value = datetime(2026, 3, 15, 9, 0, 0, tzinfo=timezone.utc)
+    mock_datetime.fromisoformat = datetime.fromisoformat
+    mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
     mock_db.query.return_value = create_mock_query([])
 
     def refresh_side_effect(obj):
@@ -371,6 +376,7 @@ def test_create_competition_with_email(mock_commit, mock_send_emails, client, mo
 
     response = client.post("/competitions/create", json=payload)
     assert response.status_code == 201
+    mock_send_emails.assert_called_once()
 
 
 @patch('src.endpoints.competitions_api.send_competition_emails')

--- a/frontend/src/components/layout/NavUser.tsx
+++ b/frontend/src/components/layout/NavUser.tsx
@@ -2,6 +2,10 @@ import * as React from "react"
 import {
   BadgeCheck,
   LogOut,
+  Moon,
+  Sun,
+  Palette,
+  Check,
 } from "lucide-react"
 import {
   DropdownMenu,
@@ -11,12 +15,17 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuPortal,
 } from "@/components/ui/dropdown-menu"
 import { logout, getProfile } from "@/api/AuthAPI"
 import { useNavigate } from "react-router-dom"
 import { AvatarInitials } from "../helpers/AvatarInitials"
 import type { Account } from "@/types/account/Account.type"
 import { logFrontend } from '../../api/LoggerAPI';
+import { getUserPreferences, updateUserPreferences } from "@/api/AccountsAPI";
 
 interface NavUserProps {
   user?: Account | null;
@@ -26,21 +35,91 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
   const navigate = useNavigate();
   const [localUser, setLocalUser] = React.useState<Account | null>(user ?? null)
 
+  // Initialize theme state from localStorage
+  const [theme, setTheme] = React.useState<"light" | "dark">(() => {
+    return (localStorage.getItem("theme") as "light" | "dark") ?? "light";
+  });
+
   React.useEffect(() => {
-    // If a user prop is not provided, fetch profile ourselves.
+    const syncTheme = () => {
+      const current = (localStorage.getItem("theme") as "light" | "dark") ?? "light";
+      setTheme(current);
+      // Ensure the DOM actually matches what was just set in localStorage
+      if (current === "dark") {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+    };
+
+    window.addEventListener("storage", syncTheme);
+    window.addEventListener("storage_sync", syncTheme);
+
+    return () => {
+      window.removeEventListener("storage", syncTheme);
+      window.removeEventListener("storage_sync", syncTheme);
+    };
+  }, []);
+
+  const handleThemeChange = async (newTheme: "light" | "dark") => {
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+
+    // Tell other components (like ProfilePage) to update their buttons
+    window.dispatchEvent(new Event("storage_sync"));
+
+    if (localUser?.id) {
+      try {
+        await updateUserPreferences(localUser.id, {
+          theme: newTheme,
+          notifications_enabled: true,
+        });
+      } catch (err) {
+        logFrontend({
+          level: 'ERROR',
+          message: `Failed to auto-save theme preference: ${(err as Error).message}`,
+          component: 'NavUser',
+          url: globalThis.location.href,
+        });
+      }
+    }
+  };
+
+  React.useEffect(() => {
     if (user) return
     let mounted = true
+
     const fetch = async () => {
       try {
-        const profile = await getProfile()
-        if (mounted) setLocalUser(profile)
+      const profile = await getProfile();
+      if (!mounted) return;
+      
+      setLocalUser(profile);
+
+      // Fetch preferences from DB and sync them to the UI/Storage
+      const prefs = await getUserPreferences(profile.id);
+      if (prefs.theme) {
+        setTheme(prefs.theme);
+        localStorage.setItem("theme", prefs.theme);
+        if (prefs.theme === "dark") {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
+      }
+          
       } catch (err) {
         logFrontend({
           level: 'ERROR',
           message: `Error finding user profile: ${(err as Error).message}`,
           component: 'NavUser',
           url: globalThis.location.href,
-          stack: (err as Error).stack,
         });
       }
     }
@@ -51,7 +130,6 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
   const handleLogout = async () => {
     try {
       await logout();
-      alert("You have been logged out.");
       navigate('/');
       localStorage.removeItem("theme");
       document.documentElement.classList.remove("dark");
@@ -61,39 +139,22 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
         message: `Error logging out: ${(err as Error).message}`,
         component: 'NavUser',
         url: globalThis.location.href,
-        stack: (err as Error).stack,
       });
-
-      // Narrow the type
-      if (err instanceof Error) {
-        alert(err.message);
-      } else if (typeof err === "object" && err !== null && "response" in err) {
-        const axiosError = err as { response?: { data?: { error?: string } } };
-        alert(axiosError.response?.data?.error || "An unknown error occurred during logout");
-      } else {
-        alert(String(err));
-      }
     }
   };
 
   const handleProfileClick = () => {
     navigate('/app/profile');
-    logFrontend({
-      level: 'INFO',
-      message: `Navigated to the user profile page.`,
-      component: 'NavUser',
-      url: globalThis.location.href,
-    });
   };
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="cursor-pointer flex items-center gap-2 rounded-xl hover:bg-muted/80 outline-none">
+        <button className="cursor-pointer flex items-center gap-2 rounded-xl hover:bg-muted/80 outline-none p-1">
           <div className="hidden sm:grid flex-1 text-left text-sm leading-tight">
             <span className="truncate font-medium ml-2">{localUser?.firstName} {localUser?.lastName}</span>
           </div>
-          <AvatarInitials className=""
+          <AvatarInitials
             firstName={localUser?.firstName ?? ""}
             lastName={localUser?.lastName ?? ""}
             size="ml"
@@ -101,7 +162,7 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+        className="w-56 rounded-lg"
         side={"bottom"}
         align="end"
         sideOffset={4}
@@ -114,23 +175,46 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
               size="md"
             />
             <div className="grid flex-1 text-left text-sm leading-tight">
-              <span className="truncate text-xs">{localUser?.email}</span>
+              <span className="truncate font-semibold">{localUser?.firstName}</span>
+              <span className="truncate text-xs text-muted-foreground">{localUser?.email}</span>
             </div>
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuItem onClick={handleProfileClick}>
-            <BadgeCheck />
+            <BadgeCheck className="mr-2 h-4 w-4" />
             Profile
           </DropdownMenuItem>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Palette className="mr-2 h-4 w-4" />
+              <span>Theme</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem onClick={() => handleThemeChange("light")}>
+                  <Sun className="mr-2 h-4 w-4" />
+                  <span>Light</span>
+                  {theme === "light" && <Check className="ml-auto h-4 w-4" />}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleThemeChange("dark")}>
+                  <Moon className="mr-2 h-4 w-4" />
+                  <span>Dark</span>
+                  {theme === "dark" && <Check className="ml-auto h-4 w-4" />}
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
         </DropdownMenuGroup>
+
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={handleLogout}>
-          <LogOut />
+          <LogOut className="mr-2 h-4 w-4" />
           Log out
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
-  )
+  );
 }

--- a/frontend/src/components/layout/NavUser.tsx
+++ b/frontend/src/components/layout/NavUser.tsx
@@ -218,3 +218,5 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
     </DropdownMenu>
   );
 }
+
+export default NavUser;

--- a/frontend/src/components/layout/NavUser.tsx
+++ b/frontend/src/components/layout/NavUser.tsx
@@ -52,12 +52,12 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
       }
     };
 
-    window.addEventListener("storage", syncTheme);
-    window.addEventListener("storage_sync", syncTheme);
+    globalThis.addEventListener("storage", syncTheme);
+    globalThis.addEventListener("storage_sync", syncTheme);
 
     return () => {
-      window.removeEventListener("storage", syncTheme);
-      window.removeEventListener("storage_sync", syncTheme);
+      globalThis.removeEventListener("storage", syncTheme);
+      globalThis.removeEventListener("storage_sync", syncTheme);
     };
   }, []);
 
@@ -72,7 +72,7 @@ export function NavUser({ user }: Readonly<NavUserProps>) {
     }
 
     // Tell other components (like ProfilePage) to update their buttons
-    window.dispatchEvent(new Event("storage_sync"));
+    globalThis.dispatchEvent(new Event("storage_sync"));
 
     if (localUser?.id) {
       try {

--- a/frontend/src/views/ProfilePage.tsx
+++ b/frontend/src/views/ProfilePage.tsx
@@ -287,7 +287,7 @@ function ProfilePage() {
       setUser({ ...updatedAccount, isGoogleUser: user.isGoogleUser });
       toast.success("Profile updated successfully.");
       setEditingField(null);
-    } catch (error) {
+    } catch {
       trackProfileFieldSaveFailed(editingField, "Error saving field");
       toast.error(`Failed to update ${editingField}.`);
     } finally {

--- a/frontend/src/views/ProfilePage.tsx
+++ b/frontend/src/views/ProfilePage.tsx
@@ -158,17 +158,17 @@ function ProfilePage() {
       if (currentTheme === "light" || currentTheme === "dark") {
         setPreferences((prev) => ({
           ...prev,
-          theme: currentTheme as "light" | "dark"
+          theme: currentTheme
         }));
       }
     };
 
-    window.addEventListener("storage", handleThemeSync);      // For other tabs
-    window.addEventListener("storage_sync", handleThemeSync); // For NavUser in this tab
+    globalThis.addEventListener("storage", handleThemeSync);      // For other tabs
+    globalThis.addEventListener("storage_sync", handleThemeSync); // For NavUser in this tab
 
     return () => {
-      window.removeEventListener("storage", handleThemeSync);
-      window.removeEventListener("storage_sync", handleThemeSync);
+      globalThis.removeEventListener("storage", handleThemeSync);
+      globalThis.removeEventListener("storage_sync", handleThemeSync);
     };
   }, []);
 
@@ -242,7 +242,7 @@ function ProfilePage() {
         localStorage.setItem("theme", "light");
       }
 
-      window.dispatchEvent(new Event("storage_sync"));
+      globalThis.dispatchEvent(new Event("storage_sync"));
     }
 
     try {

--- a/frontend/src/views/ProfilePage.tsx
+++ b/frontend/src/views/ProfilePage.tsx
@@ -132,16 +132,12 @@ function ProfilePage() {
   const [user, setUser] = React.useState<ProfileAccount | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [isSaving, setIsSaving] = React.useState(false);
-  const storedTheme = localStorage.getItem("theme") as "light" | "dark" | null;
+
   const [preferences, setPreferences] = React.useState<UserPreferences>({
-    theme: storedTheme ?? "light",
+    theme: (localStorage.getItem("theme") as "light" | "dark") ?? "light",
     notifications_enabled: true,
   });
-  const [savedPreferences, setSavedPreferences] = React.useState<UserPreferences>({
-    theme: storedTheme ?? "light",
-    notifications_enabled: true,
-  });
-  const [isSavingPrefs, setIsSavingPrefs] = React.useState(false);
+
   const navigate = useNavigate();
   const outlet = useOutlet();
   const {
@@ -152,15 +148,32 @@ function ProfilePage() {
     trackChangePasswordNavigated,
   } = useAnalytics();
 
-  const [editingField, setEditingField] = React.useState<EditableFieldName | null>(
-    null
-  );
+  const [editingField, setEditingField] = React.useState<EditableFieldName | null>(null);
   const [tempValue, setTempValue] = React.useState("");
 
-  // Track profile view once on mount
+  React.useEffect(() => {
+    const handleThemeSync = () => {
+      // Read directly from storage to ensure we have the latest value
+      const currentTheme = localStorage.getItem("theme");
+      if (currentTheme === "light" || currentTheme === "dark") {
+        setPreferences((prev) => ({
+          ...prev,
+          theme: currentTheme as "light" | "dark"
+        }));
+      }
+    };
+
+    window.addEventListener("storage", handleThemeSync);      // For other tabs
+    window.addEventListener("storage_sync", handleThemeSync); // For NavUser in this tab
+
+    return () => {
+      window.removeEventListener("storage", handleThemeSync);
+      window.removeEventListener("storage_sync", handleThemeSync);
+    };
+  }, []);
+
   React.useEffect(() => {
     trackProfileViewed();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {
@@ -179,19 +192,13 @@ function ProfilePage() {
           isGoogleAccount(),
         ]);
         setUser({
-          id: currentAccount.id,
-          firstName: currentAccount.firstName,
-          lastName: currentAccount.lastName,
-          email: currentAccount.email,
-          accountType: currentAccount.accountType,
+          ...currentAccount,
           isGoogleUser: googleStatus.isGoogleUser,
         });
 
-        // Fetch preferences after we have the user id
         try {
           const prefs = await getUserPreferences(currentAccount.id);
           setPreferences(prefs);
-          setSavedPreferences(prefs);
         } catch {
           logFrontend({
             level: "ERROR",
@@ -216,21 +223,42 @@ function ProfilePage() {
     fetchUser();
   }, []);
 
-  React.useEffect(() => {
-    const root = document.documentElement;
-    if (savedPreferences.theme === "dark") {
-      root.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      root.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [savedPreferences.theme]);
+  // Automatic saving handler
+  const handlePreferenceChange = async (updates: Partial<UserPreferences>) => {
+    if (!user) return;
 
-  const startEditing = (
-    field: EditableFieldName,
-    value: string
-  ) => {
+    // Optimistically update local state
+    const updatedPrefs = { ...preferences, ...updates };
+    setPreferences(updatedPrefs);
+
+    // Immediate UI feedback for theme
+    if (updates.theme) {
+      const root = document.documentElement;
+      if (updates.theme === "dark") {
+        root.classList.add("dark");
+        localStorage.setItem("theme", "dark");
+      } else {
+        root.classList.remove("dark");
+        localStorage.setItem("theme", "light");
+      }
+
+      window.dispatchEvent(new Event("storage_sync"));
+    }
+
+    try {
+      await updateUserPreferences(user.id, updatedPrefs);
+    } catch (error) {
+      toast.error("Failed to sync preferences.");
+      logFrontend({
+        level: "ERROR",
+        message: `Auto-save failed: ${error}`,
+        component: "ProfilePage",
+        url: globalThis.location.href,
+      });
+    }
+  };
+
+  const startEditing = (field: EditableFieldName, value: string) => {
     setEditingField(field);
     setTempValue(value);
     trackProfileFieldEdited(field);
@@ -241,28 +269,8 @@ function ProfilePage() {
     setTempValue("");
   };
 
-  const preferencesChanged =
-    preferences.theme !== savedPreferences.theme ||
-    preferences.notifications_enabled !== savedPreferences.notifications_enabled;
-
-  const savePreferences = async () => {
-    if (!user) return;
-    setIsSavingPrefs(true);
-    try {
-      const updated = await updateUserPreferences(user.id, preferences);
-      setPreferences(updated);
-      setSavedPreferences(updated);
-      toast.success("Preferences saved.");
-    } catch {
-      toast.error("Failed to save preferences.");
-    } finally {
-      setIsSavingPrefs(false);
-    }
-  };
-
   const saveField = async () => {
     if (!user || !editingField) return;
-
     setIsSaving(true);
 
     const fieldMapping: Record<string, string> = {
@@ -271,30 +279,17 @@ function ProfilePage() {
       email: "email",
     };
 
-    const backendKey = fieldMapping[editingField];
-
     try {
       const updatedAccount = await updateAccount(user.id, {
-        [backendKey]: tempValue,
+        [fieldMapping[editingField]]: tempValue,
       });
-
       trackProfileFieldSaved(editingField);
-      setUser(updatedAccount);
-
-      const fieldLabel =
-        editingField.charAt(0).toUpperCase() +
-        editingField.slice(1).replaceAll(/([A-Z])/g, " $1").toLowerCase();
-
-      toast.success(`${fieldLabel} updated successfully.`);
-
+      setUser({ ...updatedAccount, isGoogleUser: user.isGoogleUser });
+      toast.success("Profile updated successfully.");
       setEditingField(null);
-      setTempValue("");
     } catch (error) {
-      trackProfileFieldSaveFailed(
-        editingField,
-        error instanceof Error ? error.message : "Unknown error"
-      );
-      toast.error(`Failed to update ${editingField.toLowerCase()}.`);
+      trackProfileFieldSaveFailed(editingField, "Error saving field");
+      toast.error(`Failed to update ${editingField}.`);
     } finally {
       setIsSaving(false);
     }
@@ -305,9 +300,7 @@ function ProfilePage() {
     navigate("changePassword");
   };
 
-  if (outlet) {
-    return outlet;
-  }
+  if (outlet) return outlet;
 
   if (loading) {
     return (
@@ -320,7 +313,7 @@ function ProfilePage() {
   return (
     <div className="container mx-auto max-w-5xl p-6 md:p-10 space-y-10 animate-in fade-in duration-500">
       {/* Header Section */}
-      <div className="flex flex-col md:flex-row items-center md:items-center gap-8">
+      <div className="flex flex-col md:flex-row items-center gap-8">
         <div className="relative group">
           <div className="size-35 rounded-full border-4 border-card overflow-hidden ring-2 ring-primary/50 flex items-center justify-center">
             <AvatarInitials
@@ -345,18 +338,15 @@ function ProfilePage() {
 
       <Separator />
 
-      {/* Content */}
+      {/* Personal Info */}
       <div className="lg:col-span-2 space-y-6">
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold flex items-center gap-2">
-            <IdCard className="h-5 w-5 text-primary" />
-            Personal Information
-          </h2>
-        </div>
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <IdCard className="h-5 w-5 text-primary" />
+          Personal Information
+        </h2>
 
         <Card className="rounded-3xl overflow-hidden">
           <CardContent className="p-8 space-y-8">
-            {/* First Name Field */}
             <EditableField
               icon={<User className="h-4 w-4 opacity-70 text-primary" />}
               label="First Name"
@@ -370,10 +360,7 @@ function ProfilePage() {
               onCancel={cancelEditing}
               onTempValueChange={setTempValue}
             />
-
             <Separator className="opacity-60" />
-
-            {/* Last Name Field */}
             <EditableField
               icon={<User className="h-4 w-4 opacity-70 text-primary" />}
               label="Last Name"
@@ -387,10 +374,7 @@ function ProfilePage() {
               onCancel={cancelEditing}
               onTempValueChange={setTempValue}
             />
-
             <Separator className="opacity-60" />
-
-            {/* Email Field */}
             <EditableField
               icon={<Mail className="h-4 w-4 opacity-70 text-primary" />}
               label="Email"
@@ -406,10 +390,7 @@ function ProfilePage() {
               onCancel={cancelEditing}
               onTempValueChange={setTempValue}
             />
-
             <Separator className="opacity-50" />
-
-            {/* Password Field */}
             <div className="pt-2">
               {user?.isGoogleUser ? (
                 <div className="space-y-3">
@@ -417,19 +398,15 @@ function ProfilePage() {
                     <KeyRound className="h-4 w-4 opacity-70 text-primary" /> Password
                   </Label>
                   <div className="flex items-center justify-between group min-h-10">
-                    <Label className="text-muted-foreground text-base font-normal tracking-widest">
-                      ••••••••••••
-                    </Label>
-                    <span className="text-[10px] uppercase font-bold text-primary/60 tracking-wider">
-                      Managed by Google
-                    </span>
+                    <Label className="text-muted-foreground text-base font-normal tracking-widest">••••••••••••</Label>
+                    <span className="text-[10px] uppercase font-bold text-primary/60 tracking-wider">Managed by Google</span>
                   </div>
                 </div>
               ) : (
                 <div className="flex justify-end">
                   <Button
                     variant="ghost"
-                    className="h-9 px-4 text-sm font-medium text-primary hover:bg-primary/10 hover:text-primary transition-all"
+                    className="h-9 px-4 text-sm font-medium text-primary hover:bg-primary/10 transition-all"
                     onClick={handleChangePasswordNavigation}
                   >
                     Change Password
@@ -440,59 +417,36 @@ function ProfilePage() {
           </CardContent>
         </Card>
 
-        {user?.isGoogleUser && (
-          <div className="bg-blue-50/50 border border-blue-100 p-4 rounded-2xl">
-            <p className="text-xs text-blue-600/80 leading-relaxed text-center">
-              You signed in with Google. To change your password, please manage
-              your settings through your{" "}
-              <a
-                href="https://myaccount.google.com/security"
-                target="_blank"
-                rel="noreferrer"
-                className="underline font-semibold"
-              >
-                Google Account
-              </a>
-              {" "}.
-            </p>
-          </div>
-        )}
-
         {/* Preferences Section */}
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold flex items-center gap-2">
-            <Settings2 className="h-5 w-5 text-primary" />
-            Preferences
-          </h2>
-        </div>
+        <h2 className="text-lg font-semibold flex items-center gap-2 pt-4">
+          <Settings2 className="h-5 w-5 text-primary" />
+          Preferences
+        </h2>
 
         <Card className="rounded-3xl overflow-hidden">
           <CardContent className="p-8 space-y-8">
-            {/* Theme */}
             <div className="space-y-3">
               <Label className="text-sm font-semibold flex items-center gap-2">
-                {preferences.theme === "dark"
-                  ? <Moon className="h-4 w-4 opacity-70 text-primary" />
-                  : <Sun className="h-4 w-4 opacity-70 text-primary" />}
+                {preferences.theme === "dark" ? <Moon className="h-4 w-4 opacity-70 text-primary" /> : <Sun className="h-4 w-4 opacity-70 text-primary" />}
                 Theme
               </Label>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => setPreferences((p) => ({ ...p, theme: "light" }))}
+                  onClick={() => handlePreferenceChange({ theme: "light" })}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium border transition-all ${preferences.theme === "light"
-                    ? "bg-primary text-primary-foreground border-primary shadow-sm"
-                    : "bg-transparent text-muted-foreground border-border hover:border-primary/40 hover:text-foreground"
+                      ? "bg-primary text-primary-foreground border-primary shadow-sm"
+                      : "bg-transparent text-muted-foreground border-border hover:border-primary/40"
                     }`}
                 >
                   <Sun className="h-4 w-4" /> Light
                 </button>
                 <button
                   type="button"
-                  onClick={() => setPreferences((p) => ({ ...p, theme: "dark" }))}
+                  onClick={() => handlePreferenceChange({ theme: "dark" })}
                   className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium border transition-all ${preferences.theme === "dark"
-                    ? "bg-primary text-primary-foreground border-primary shadow-sm"
-                    : "bg-transparent text-muted-foreground border-border hover:border-primary/40 hover:text-foreground"
+                      ? "bg-primary text-primary-foreground border-primary shadow-sm"
+                      : "bg-transparent text-muted-foreground border-border hover:border-primary/40"
                     }`}
                 >
                   <Moon className="h-4 w-4" /> Dark
@@ -502,52 +456,24 @@ function ProfilePage() {
 
             <Separator className="opacity-60" />
 
-            {/* Notifications */}
             <div className="space-y-3">
               <Label className="text-sm font-semibold flex items-center gap-2">
                 <Bell className="h-4 w-4 opacity-70 text-primary" /> Notifications
               </Label>
               <div className="flex items-center justify-between min-h-10">
-                <Label className="text-muted-foreground text-base font-normal">
-                  Enable email notifications
-                </Label>
+                <Label className="text-muted-foreground text-base font-normal">Enable email notifications</Label>
                 <button
                   type="button"
                   role="switch"
                   aria-checked={preferences.notifications_enabled}
-                  onClick={() =>
-                    setPreferences((p) => ({
-                      ...p,
-                      notifications_enabled: !p.notifications_enabled,
-                    }))
-                  }
-                  className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${preferences.notifications_enabled ? "bg-primary" : "bg-input"
+                  onClick={() => handlePreferenceChange({ notifications_enabled: !preferences.notifications_enabled })}
+                  className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${preferences.notifications_enabled ? "bg-primary" : "bg-input"
                     }`}
                 >
-                  <span
-                    className={`pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform duration-200 ${preferences.notifications_enabled ? "translate-x-5" : "translate-x-0"
-                      }`}
-                  />
+                  <span className={`pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg transition-transform duration-200 ${preferences.notifications_enabled ? "translate-x-5" : "translate-x-0"
+                    }`} />
                 </button>
               </div>
-            </div>
-
-            {/* Save Button */}
-            <div className="flex justify-end pt-2">
-              <Button
-                onClick={savePreferences}
-                disabled={!preferencesChanged || isSavingPrefs}
-                className="h-9 px-6 text-sm font-medium disabled:opacity-40"
-              >
-                {isSavingPrefs ? (
-                  <span className="flex items-center gap-2">
-                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />{' '}
-                    Saving…
-                  </span>
-                ) : (
-                  "Save Preferences"
-                )}
-              </Button>
             </div>
           </CardContent>
         </Card>

--- a/frontend/tests/NavUser.test.tsx
+++ b/frontend/tests/NavUser.test.tsx
@@ -1,424 +1,314 @@
-/// <reference types="jest" />
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NavUser } from '../src/components/layout/NavUser'
+import { logout, getProfile } from '../src/api/AuthAPI'
+import { getUserPreferences, updateUserPreferences } from '../src/api/AccountsAPI'
+import { logFrontend } from '../src/api/LoggerAPI'
+import { useNavigate } from 'react-router-dom'
+import { Account } from '../src/types/account/Account.type'
 
-import { render, screen, within, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { NavUser } from "../src/components/layout/NavUser";
+// ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const { TextEncoder, TextDecoder } = require('util');
+jest.mock('../src/api/AuthAPI', () => ({
+    logout: jest.fn(),
+    getProfile: jest.fn(),
+}))
 
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
+jest.mock('../src/api/AccountsAPI', () => ({
+    getUserPreferences: jest.fn(),
+    updateUserPreferences: jest.fn(),
+}))
 
-// Mock the sidebar hook
-const mockUseSidebar = jest.fn();
+jest.mock('../src/api/LoggerAPI', () => ({
+    logFrontend: jest.fn(),
+}))
 
-// Mock react-router-dom
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  useNavigate: () => mockNavigate,
-}));
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+}))
 
-// Mock the auth API — covers both logout and getProfile (used when no user prop)
-jest.mock("../src/api/AuthAPI", () => ({
-  logout: jest.fn(),
-  getProfile: jest.fn(() =>
-    Promise.resolve({
-      id: "1",
-      firstName: "John",
-      lastName: "Doe",
-      email: "john.doe@example.com",
-      accountType: "user",
+jest.mock('../src/components/helpers/AvatarInitials', () => ({
+    AvatarInitials: ({ firstName, lastName }: any) => (
+        <div data-testid="avatar">{firstName[0]}{lastName[0]}</div>
+    ),
+}))
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const mockUser: Account = {
+    id: 1,
+    firstName: 'Julia',
+    lastName: 'Doe',
+    email: 'julia@test.com',
+    accountType: 'Participant',
+}
+
+const mockNavigate = jest.fn()
+const mockedLogout = logout as jest.Mock
+const mockedGetProfile = getProfile as jest.Mock
+const mockedGetUserPreferences = getUserPreferences as jest.Mock
+const mockedUpdateUserPreferences = updateUserPreferences as jest.Mock
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// Opens the main dropdown
+const openDropdown = async () => {
+    await userEvent.click(screen.getByRole('button'))
+}
+
+// Opens the main dropdown then hovers Theme to reveal the submenu
+const openThemeSubmenu = async () => {
+    await openDropdown()
+    await userEvent.hover(screen.getByText('Theme'))
+    // Wait for the submenu items to appear
+    await waitFor(() => screen.getByText('Dark'))
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useNavigate as jest.Mock).mockReturnValue(mockNavigate)
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+    mockedGetProfile.mockResolvedValue(mockUser)
+    mockedGetUserPreferences.mockResolvedValue({ theme: 'light', notifications_enabled: true })
+    mockedUpdateUserPreferences.mockResolvedValue({})
+    mockedLogout.mockResolvedValue(undefined)
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('NavUser — rendering', () => {
+    it('renders user name when user prop is provided', () => {
+        render(<NavUser user={mockUser} />)
+        expect(screen.getByText('Julia Doe')).toBeInTheDocument()
     })
-  ),
-}));
 
-// Mock the logger API
-jest.mock("../src/api/LoggerAPI", () => ({
-  logFrontend: jest.fn(),
-}));
+    it('renders avatar with initials', () => {
+        render(<NavUser user={mockUser} />)
+        expect(screen.getAllByTestId('avatar').length).toBeGreaterThan(0)
+    })
 
-// Mock AvatarInitials helper
-jest.mock("../src/components/helpers/AvatarInitials", () => ({
-  AvatarInitials: ({ firstName, lastName }: any) => {
-    const initials = `${firstName?.charAt(0) ?? ""}${lastName?.charAt(0) ?? ""}`.toUpperCase();
-    return <div data-testid="avatar-fallback">{initials}</div>;
-  },
-}));
+    it('renders with no user prop (null)', async () => {
+        render(<NavUser user={null} />)
+        await waitFor(() => expect(mockedGetProfile).toHaveBeenCalled())
+    })
 
-// NavUser no longer wraps itself in SidebarMenu — only the useSidebar hook is used
-jest.mock("@/components/ui/sidebar", () => ({
-  useSidebar: () => mockUseSidebar(),
-}));
+    it('fetches and displays profile when no user prop is given', async () => {
+        render(<NavUser />)
+        await waitFor(() =>
+            expect(screen.getByText('Julia Doe')).toBeInTheDocument()
+        )
+    })
 
-jest.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: any) => (
-    <div data-testid="dropdown-menu">{children}</div>
-  ),
-  DropdownMenuTrigger: ({ children }: any) => (
-    <div data-testid="dropdown-menu-trigger">{children}</div>
-  ),
-  DropdownMenuContent: ({ children, side, align, sideOffset, className }: any) => (
-    <div
-      data-testid="dropdown-menu-content"
-      data-side={side}
-      data-align={align}
-      data-side-offset={sideOffset}
-      className={className}
-    >
-      {children}
-    </div>
-  ),
-  DropdownMenuLabel: ({ children, className }: any) => (
-    <div data-testid="dropdown-menu-label" className={className}>
-      {children}
-    </div>
-  ),
-  DropdownMenuGroup: ({ children }: any) => (
-    <div data-testid="dropdown-menu-group">{children}</div>
-  ),
-  DropdownMenuItem: ({ children, onClick }: any) => (
-    <div role="menuitem" data-testid="dropdown-menu-item" onClick={onClick}>
-      {children}
-    </div>
-  ),
-  DropdownMenuSeparator: () => <hr data-testid="dropdown-menu-separator" />,
-}));
+    it('renders user email in dropdown after opening', async () => {
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        expect(screen.getByText('julia@test.com')).toBeInTheDocument()
+    })
 
-jest.mock("lucide-react", () => ({
-  BadgeCheck: () => <svg data-testid="badge-check-icon" />,
-  ChevronsUpDown: () => <svg data-testid="chevrons-up-down-icon" />,
-  LogOut: () => <svg data-testid="log-out-icon" />,
-}));
+    it('renders Profile and Log out menu items after opening', async () => {
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        expect(screen.getByText('Profile')).toBeInTheDocument()
+        expect(screen.getByText('Log out')).toBeInTheDocument()
+    })
 
-describe("NavUser", () => {
-  const mockUser = {
-    id: "1",
-    firstName: "John",
-    lastName: "Doe",
-    email: "john.doe@example.com",
-    accountType: "user",
-  };
+    it('renders Theme submenu trigger after opening', async () => {
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        expect(screen.getByText('Theme')).toBeInTheDocument()
+    })
+})
 
-  beforeEach(() => {
-    mockUseSidebar.mockReturnValue({ isMobile: false });
-    mockNavigate.mockClear();
-    jest.clearAllMocks();
-    // Restore sidebar mock after clearAllMocks
-    mockUseSidebar.mockReturnValue({ isMobile: false });
-  });
+describe('NavUser — profile fetch', () => {
+    it('calls getProfile when user prop is not provided', async () => {
+        render(<NavUser />)
+        await waitFor(() => expect(mockedGetProfile).toHaveBeenCalledTimes(1))
+    })
 
-  describe("Trigger Button", () => {
-    test("renders a plain button as the dropdown trigger (not SidebarMenuButton)", () => {
-      render(<NavUser user={mockUser as any} />);
-      // The trigger should be a regular button inside the dropdown trigger wrapper
-      const trigger = screen.getByTestId("dropdown-menu-trigger");
-      const button = trigger.querySelector("button");
-      expect(button).toBeInTheDocument();
-    });
+    it('does not call getProfile when user prop is provided', async () => {
+        render(<NavUser user={mockUser} />)
+        await new Promise(r => setTimeout(r, 50))
+        expect(mockedGetProfile).not.toHaveBeenCalled()
+    })
 
-    test("trigger button shows user name", () => {
-      render(<NavUser user={mockUser as any} />);
-      const trigger = screen.getByTestId("dropdown-menu-trigger");
-      expect(within(trigger).getByText("John Doe")).toBeInTheDocument();
-    });
+    it('syncs dark theme from DB preferences on mount', async () => {
+        mockedGetUserPreferences.mockResolvedValue({ theme: 'dark', notifications_enabled: true })
+        render(<NavUser />)
+        await waitFor(() =>
+            expect(document.documentElement.classList.contains('dark')).toBe(true)
+        )
+        expect(localStorage.getItem('theme')).toBe('dark')
+    })
 
-    test("trigger button renders avatar initials", () => {
-      render(<NavUser user={mockUser as any} />);
-      const trigger = screen.getByTestId("dropdown-menu-trigger");
-      expect(within(trigger).getByTestId("avatar-fallback")).toBeInTheDocument();
-    });
-  });
+    it('does not apply theme if prefs.theme is falsy', async () => {
+        mockedGetUserPreferences.mockResolvedValue({ theme: null, notifications_enabled: true })
+        render(<NavUser />)
+        await waitFor(() => expect(mockedGetProfile).toHaveBeenCalled())
+        expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
 
-  describe("Profile self-fetch (no user prop)", () => {
-    test("fetches and displays profile when no user prop is provided", async () => {
-      const { getProfile } = require("../src/api/AuthAPI");
-      render(<NavUser />);
-      expect(getProfile).toHaveBeenCalled();
-      // After fetch, name should appear (rendered in both trigger and dropdown label)
-      const names = await screen.findAllByText("John Doe");
-      expect(names.length).toBeGreaterThanOrEqual(1);
-    });
+    it('logs error when getProfile fails', async () => {
+        mockedGetProfile.mockRejectedValueOnce(new Error('auth failure'))
+        render(<NavUser />)
+        await waitFor(() =>
+            expect(logFrontend).toHaveBeenCalledWith(
+                expect.objectContaining({ level: 'ERROR', component: 'NavUser' })
+            )
+        )
+    })
+})
 
-    test("does not call getProfile when user prop is provided", () => {
-      const { getProfile } = require("../src/api/AuthAPI");
-      render(<NavUser user={mockUser as any} />);
-      expect(getProfile).not.toHaveBeenCalled();
-    });
+describe('NavUser — theme switching', () => {
+    it('shows Light and Dark options in theme submenu', async () => {
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        expect(screen.getByText('Light')).toBeInTheDocument()
+        expect(screen.getByText('Dark')).toBeInTheDocument()
+    })
 
-    // Covers line 40: logFrontend call inside the getProfile catch block
-    test("logs error to console when getProfile fails", async () => {
-      const { getProfile } = require("../src/api/AuthAPI");
-      const { logFrontend } = require("../src/api/LoggerAPI");
-      const fetchError = new Error("Network error");
-      (getProfile as jest.Mock).mockRejectedValueOnce(fetchError);
+    it('applies dark class when dark theme selected', async () => {
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Dark'))
+        expect(document.documentElement.classList.contains('dark')).toBe(true)
+        expect(localStorage.getItem('theme')).toBe('dark')
+    })
 
-      render(<NavUser />);
+    it('removes dark class when light theme selected', async () => {
+        document.documentElement.classList.add('dark')
+        localStorage.setItem('theme', 'dark')
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Light'))
+        expect(document.documentElement.classList.contains('dark')).toBe(false)
+        expect(localStorage.getItem('theme')).toBe('light')
+    })
 
-      await waitFor(() => {
-        expect(logFrontend).toHaveBeenCalledWith(
-          expect.objectContaining({
-            level: "ERROR",
-            message: expect.stringContaining("Network error"),
-            component: "NavUser",
-          })
-        );
-      });
+    it('calls updateUserPreferences when theme changes', async () => {
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Dark'))
+        await waitFor(() =>
+            expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(
+                mockUser.id,
+                expect.objectContaining({ theme: 'dark' })
+            )
+        )
+    })
 
-      // localUser should remain null — no name rendered in trigger
-      const trigger = screen.getByTestId("dropdown-menu-trigger");
-      expect(within(trigger).queryByText(/\S/)).toBeNull();
-    });
-  });
+    it('does not call updateUserPreferences when user has no id', async () => {
+        render(<NavUser user={{ ...mockUser, id: undefined as any }} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Dark'))
+        await new Promise(r => setTimeout(r, 50))
+        expect(mockedUpdateUserPreferences).not.toHaveBeenCalled()
+    })
 
-  describe("Avatar Fallback", () => {
-    test("handles missing firstName gracefully", () => {
-      const userWithoutFirstName = { ...mockUser, firstName: "" } as any;
-      render(<NavUser user={userWithoutFirstName} />);
-      const fallbacks = screen.getAllByTestId("avatar-fallback");
-      fallbacks.forEach((fallback) => {
-        expect(fallback).toHaveTextContent("D");
-      });
-    });
+    it('logs error when updateUserPreferences fails', async () => {
+        mockedUpdateUserPreferences.mockRejectedValueOnce(new Error('pref error'))
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Dark'))
+        await waitFor(() =>
+            expect(logFrontend).toHaveBeenCalledWith(
+                expect.objectContaining({ level: 'ERROR', component: 'NavUser' })
+            )
+        )
+    })
 
-    test("handles missing lastName gracefully", () => {
-      const userWithoutLastName = { ...mockUser, lastName: "" } as any;
-      render(<NavUser user={userWithoutLastName} />);
-      const fallbacks = screen.getAllByTestId("avatar-fallback");
-      fallbacks.forEach((fallback) => {
-        expect(fallback).toHaveTextContent("J");
-      });
-    });
+    it('dispatches storage_sync event when theme changes', async () => {
+        const listener = jest.fn()
+        window.addEventListener('storage_sync', listener)
+        render(<NavUser user={mockUser} />)
+        await openThemeSubmenu()
+        await userEvent.click(screen.getByText('Dark'))
+        expect(listener).toHaveBeenCalled()
+        window.removeEventListener('storage_sync', listener)
+    })
 
-    test("handles both names missing gracefully", () => {
-      const userWithoutNames = { ...mockUser, firstName: "", lastName: "" } as any;
-      render(<NavUser user={userWithoutNames} />);
-      const fallbacks = screen.getAllByTestId("avatar-fallback");
-      fallbacks.forEach((fallback) => {
-        expect(fallback).toHaveTextContent("");
-      });
-    });
+    it('syncs theme when storage event fires', async () => {
+        render(<NavUser user={mockUser} />)
+        act(() => {
+            localStorage.setItem('theme', 'dark')
+            window.dispatchEvent(new Event('storage'))
+        })
+        await waitFor(() =>
+            expect(document.documentElement.classList.contains('dark')).toBe(true)
+        )
+    })
 
-    test("converts initials to uppercase", () => {
-      const userLowercase = { ...mockUser, firstName: "jane", lastName: "smith" } as any;
-      render(<NavUser user={userLowercase} />);
-      const fallbacks = screen.getAllByTestId("avatar-fallback");
-      fallbacks.forEach((fallback) => {
-        expect(fallback).toHaveTextContent("JS");
-      });
-    });
-  });
+    it('syncs theme when storage_sync event fires', async () => {
+        render(<NavUser user={mockUser} />)
+        act(() => {
+            localStorage.setItem('theme', 'dark')
+            window.dispatchEvent(new Event('storage_sync'))
+        })
+        await waitFor(() =>
+            expect(document.documentElement.classList.contains('dark')).toBe(true)
+        )
+    })
+})
 
-  describe("Dropdown Menu", () => {
-    test("renders dropdown menu structure", () => {
-      render(<NavUser user={mockUser as any} />);
-      expect(screen.getByTestId("dropdown-menu")).toBeInTheDocument();
-      expect(screen.getByTestId("dropdown-menu-trigger")).toBeInTheDocument();
-      expect(screen.getByTestId("dropdown-menu-content")).toBeInTheDocument();
-    });
+describe('NavUser — logout', () => {
+    it('calls logout and navigates to / on log out click', async () => {
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Log out'))
+        await waitFor(() => expect(mockedLogout).toHaveBeenCalledTimes(1))
+        expect(mockNavigate).toHaveBeenCalledWith('/')
+    })
 
-    test("renders dropdown menu label with user info", () => {
-      render(<NavUser user={mockUser as any} />);
-      const label = screen.getByTestId("dropdown-menu-label");
-      // expect(within(label).getByText("John Doe")).toBeInTheDocument();
-      expect(within(label).getByText("john.doe@example.com")).toBeInTheDocument();
-    });
+    it('removes theme from localStorage on logout', async () => {
+        localStorage.setItem('theme', 'dark')
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Log out'))
+        await waitFor(() => expect(mockedLogout).toHaveBeenCalled())
+        expect(localStorage.getItem('theme')).toBeNull()
+    })
 
-    test("renders Profile menu item with icon", () => {
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      expect(within(menuItems[0]).getByTestId("badge-check-icon")).toBeInTheDocument();
-      expect(within(menuItems[0]).getByText("Profile")).toBeInTheDocument();
-    });
+    it('removes dark class from documentElement on logout', async () => {
+        document.documentElement.classList.add('dark')
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Log out'))
+        await waitFor(() => expect(mockedLogout).toHaveBeenCalled())
+        expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
 
-    test("renders Log out menu item with icon", () => {
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      expect(within(menuItems[1]).getByTestId("log-out-icon")).toBeInTheDocument();
-      expect(within(menuItems[1]).getByText("Log out")).toBeInTheDocument();
-    });
+    it('logs error when logout fails', async () => {
+        mockedLogout.mockRejectedValueOnce(new Error('logout error'))
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Log out'))
+        await waitFor(() =>
+            expect(logFrontend).toHaveBeenCalledWith(
+                expect.objectContaining({ level: 'ERROR', component: 'NavUser' })
+            )
+        )
+    })
 
-    test("renders two separators in dropdown menu", () => {
-      render(<NavUser user={mockUser as any} />);
-      const separators = screen.getAllByTestId("dropdown-menu-separator");
-      expect(separators).toHaveLength(2);
-    });
+    it('does not navigate when logout throws', async () => {
+        mockedLogout.mockRejectedValueOnce(new Error('logout error'))
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Log out'))
+        await waitFor(() => expect(logFrontend).toHaveBeenCalled())
+        expect(mockNavigate).not.toHaveBeenCalled()
+    })
+})
 
-    test("renders dropdown menu group for profile actions", () => {
-      render(<NavUser user={mockUser as any} />);
-      expect(screen.getByTestId("dropdown-menu-group")).toBeInTheDocument();
-    });
-  });
-
-  describe("Mobile vs Desktop", () => {
-    test("renders dropdown on right side when not mobile", () => {
-      mockUseSidebar.mockReturnValue({ isMobile: false });
-      render(<NavUser user={mockUser as any} />);
-      const content = screen.getByTestId("dropdown-menu-content");
-      expect(content).toHaveAttribute("data-side", "bottom");
-    });
-
-    test("renders dropdown on bottom when mobile", () => {
-      mockUseSidebar.mockReturnValue({ isMobile: true });
-      render(<NavUser user={mockUser as any} />);
-      const content = screen.getByTestId("dropdown-menu-content");
-      expect(content).toHaveAttribute("data-side", "bottom");
-    });
-  });
-
-  describe("Dropdown Menu Positioning", () => {
-    test("dropdown menu aligns to end", () => {
-      render(<NavUser user={mockUser as any} />);
-      const content = screen.getByTestId("dropdown-menu-content");
-      expect(content).toHaveAttribute("data-align", "end");
-    });
-
-    test("dropdown menu has correct side offset", () => {
-      render(<NavUser user={mockUser as any} />);
-      const content = screen.getByTestId("dropdown-menu-content");
-      expect(content).toHaveAttribute("data-side-offset", "4");
-    });
-
-    test("dropdown menu content has correct className", () => {
-      render(<NavUser user={mockUser as any} />);
-      const content = screen.getByTestId("dropdown-menu-content");
-      expect(content).toHaveClass(
-        "w-(--radix-dropdown-menu-trigger-width)",
-        "min-w-56",
-        "rounded-lg"
-      );
-    });
-  });
-
-  describe("Text Truncation", () => {
-    test("user name has truncate class", () => {
-      render(<NavUser user={mockUser as any} />);
-      const names = screen.getAllByText("John Doe");
-      names.forEach((name) => {
-        expect(name).toHaveClass("truncate");
-      });
-    });
-
-    test("user email has truncate class", () => {
-      render(<NavUser user={mockUser as any} />);
-      const emails = screen.getAllByText("john.doe@example.com");
-      emails.forEach((email) => {
-        expect(email).toHaveClass("truncate");
-      });
-    });
-  });
-
-  describe("Navigation actions", () => {
-    test("navigates to /app/profile when Profile is clicked", async () => {
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[0]);
-      expect(mockNavigate).toHaveBeenCalledWith("/app/profile");
-    });
-
-    test("calls logout and navigates to '/' when Log out is clicked", async () => {
-      const { logout } = require("../src/api/AuthAPI");
-      (logout as jest.Mock).mockResolvedValue(undefined);
-      window.alert = jest.fn();
-
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[1]);
-
-      expect(logout).toHaveBeenCalled();
-      await screen.findByTestId("dropdown-menu"); // wait for async
-      expect(mockNavigate).toHaveBeenCalledWith("/");
-    });
-  });
-
-  // ─── New tests covering lines 53–67: handleLogout error branches ─────────────
-  describe("Logout error handling", () => {
-    beforeEach(() => {
-      window.alert = jest.fn();
-    });
-
-    // Covers lines 53–58: logFrontend call + instanceof Error branch (line 60–62)
-    test("alerts the error message and calls logFrontend when logout throws an Error", async () => {
-      const { logout } = require("../src/api/AuthAPI");
-      const { logFrontend } = require("../src/api/LoggerAPI");
-      const logoutError = new Error("Session expired");
-      (logout as jest.Mock).mockRejectedValueOnce(logoutError);
-
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[1]);
-
-      await waitFor(() => {
-        // logFrontend must be called with ERROR level (line 53–58)
-        expect(logFrontend).toHaveBeenCalledWith(
-          expect.objectContaining({
-            level: "ERROR",
-            message: expect.stringContaining("Session expired"),
-            component: "NavUser",
-          })
-        );
-        // instanceof Error branch: alert with err.message (line 61)
-        expect(window.alert).toHaveBeenCalledWith("Session expired");
-      });
-
-      // navigate should NOT have been called
-      expect(mockNavigate).not.toHaveBeenCalled();
-    });
-
-    // Covers lines 62–65: axios-style error branch (object with response.data.error)
-    test("alerts the server error message when logout throws an axios-style error", async () => {
-      const { logout } = require("../src/api/AuthAPI");
-      const { logFrontend } = require("../src/api/LoggerAPI");
-      const axiosError = {
-        response: { data: { error: "Unauthorized" } },
-      };
-      (logout as jest.Mock).mockRejectedValueOnce(axiosError);
-
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[1]);
-
-      await waitFor(() => {
-        // logFrontend is still called (lines 53–58); non-Error, so message uses String(err)
-        expect(logFrontend).toHaveBeenCalledWith(
-          expect.objectContaining({
-            level: "ERROR",
-            component: "NavUser",
-          })
-        );
-        // axios branch: alert with response.data.error (line 64)
-        expect(window.alert).toHaveBeenCalledWith("Unauthorized");
-      });
-    });
-
-    // Covers the axios branch fallback when response.data.error is absent
-    test("alerts generic message when axios-style error has no error string", async () => {
-      const { logout } = require("../src/api/AuthAPI");
-      const axiosError = { response: { data: {} } };
-      (logout as jest.Mock).mockRejectedValueOnce(axiosError);
-
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[1]);
-
-      await waitFor(() => {
-        expect(window.alert).toHaveBeenCalledWith(
-          "An unknown error occurred during logout"
-        );
-      });
-    });
-
-    // Covers line 66–67: plain string / other primitive error
-    test("alerts stringified error when logout throws a non-Error, non-object value", async () => {
-      const { logout } = require("../src/api/AuthAPI");
-      (logout as jest.Mock).mockRejectedValueOnce("plain string error");
-
-      render(<NavUser user={mockUser as any} />);
-      const menuItems = screen.getAllByTestId("dropdown-menu-item");
-      await userEvent.click(menuItems[1]);
-
-      await waitFor(() => {
-        expect(window.alert).toHaveBeenCalledWith("plain string error");
-      });
-    });
-  });
-});
+describe('NavUser — profile navigation', () => {
+    it('navigates to /app/profile when Profile is clicked', async () => {
+        render(<NavUser user={mockUser} />)
+        await openDropdown()
+        await userEvent.click(screen.getByText('Profile'))
+        expect(mockNavigate).toHaveBeenCalledWith('/app/profile')
+    })
+})

--- a/frontend/tests/ProfilePage.test.tsx
+++ b/frontend/tests/ProfilePage.test.tsx
@@ -4,16 +4,11 @@ import { getProfile, isGoogleAccount } from "../src/api/AuthAPI";
 import { updateAccount, getUserPreferences, updateUserPreferences } from "../src/api/AccountsAPI";
 import { useNavigate, useOutlet } from "react-router-dom";
 import { toast } from "sonner";
+import { logFrontend } from "../src/api/LoggerAPI";
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
-
-jest.mock('../src/lib/axiosClient', () => ({
-  __esModule: true,
-  default: { get: jest.fn(), post: jest.fn(), put: jest.fn(), delete: jest.fn() },
-  API_URL: 'http://localhost:8000',
-}));
 
 jest.mock("../src/api/AuthAPI", () => ({
   getProfile: jest.fn(),
@@ -49,21 +44,15 @@ jest.mock("@/hooks/useAnalytics", () => ({
 }));
 
 jest.mock("lucide-react", () => ({
-  Mail: () => <div />,
-  User: () => <div />,
-  IdCard: () => <div />,
-  Pencil: () => <span>Pencil</span>,
-  KeyRound: () => <div />,
-  Check: () => <span>Check</span>,
-  X: () => <span>X</span>,
-  Bell: () => <div />,
-  Sun: () => <div />,
-  Moon: () => <div />,
+  Mail: () => <div />, User: () => <div />, IdCard: () => <div />,
+  Pencil: () => <span>Pencil</span>, KeyRound: () => <div />,
+  Check: () => <span>Check</span>, X: () => <span>X</span>,
+  Bell: () => <div />, Sun: () => <div />, Moon: () => <div />,
   Settings2: () => <div />,
 }));
 
 jest.mock("@/components/helpers/AvatarInitials", () => ({
-  AvatarInitials: ({ firstName, lastName }: { firstName: string; lastName: string }) => (
+  AvatarInitials: ({ firstName, lastName }: any) => (
     <div data-testid="avatar-initials">{firstName?.[0]}{lastName?.[0]}</div>
   ),
 }));
@@ -73,23 +62,6 @@ jest.mock("@/components/ui/button", () => ({
     <button onClick={onClick} disabled={disabled} data-variant={variant} data-size={size} className={className}>
       {children}
     </button>
-  ),
-}));
-
-jest.mock("@/components/ui/separator", () => ({ Separator: () => <hr /> }));
-jest.mock("@/components/ui/badge", () => ({
-  Badge: ({ children, className }: any) => <span className={className}>{children}</span>,
-}));
-jest.mock("@/components/ui/card", () => ({
-  Card: ({ children, className }: any) => <div className={className}>{children}</div>,
-  CardContent: ({ children, className }: any) => <div className={className}>{children}</div>,
-}));
-jest.mock("@/components/ui/label", () => ({
-  Label: ({ children, className, htmlFor }: any) => <label htmlFor={htmlFor} className={className}>{children}</label>,
-}));
-jest.mock("@/components/ui/input", () => ({
-  Input: ({ value, onChange, disabled, autoFocus, className }: any) => (
-    <input value={value} onChange={onChange} disabled={disabled} autoFocus={autoFocus} className={className} />
   ),
 }));
 
@@ -112,35 +84,13 @@ const mockPreferences = {
 
 describe("ProfilePage Component", () => {
   const mockNavigate = jest.fn();
-  const mockReload = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
     (useOutlet as jest.Mock).mockReturnValue(null);
-
-    delete (window as any).location;
-    window.location = {
-      href: "http://localhost/app/profile",
-      origin: "http://localhost",
-      pathname: "/app/profile",
-      reload: mockReload,
-    } as any;
-
-    const sessionStorageMock = (() => {
-      let store: Record<string, string> = {};
-      return {
-        getItem: jest.fn((key: string) => store[key] || null),
-        setItem: jest.fn((key: string, value: string) => { store[key] = value.toString(); }),
-        removeItem: jest.fn((key: string) => { delete store[key]; }),
-        clear: jest.fn(() => { store = {}; }),
-      };
-    })();
-    Object.defineProperty(window, "sessionStorage", {
-      value: sessionStorageMock,
-      configurable: true,
-      writable: true,
-    });
+    localStorage.clear();
+    sessionStorage.clear();
 
     (getProfile as jest.Mock).mockResolvedValue(mockUser);
     (isGoogleAccount as jest.Mock).mockResolvedValue({ isGoogleUser: false });
@@ -160,25 +110,8 @@ describe("ProfilePage Component", () => {
     });
   });
 
-  test("displays account type badge", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      expect(screen.getByText(/participant/i)).toBeTruthy();
-    });
-  });
-
-  test("renders avatar with user initials", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      const avatar = screen.getByTestId("avatar-initials");
-      expect(avatar.textContent).toBe("JD");
-    });
-  });
-
   test("renders loading spinner while fetching profile", () => {
-    (getProfile as jest.Mock).mockImplementation(
-      () => new Promise(resolve => setTimeout(() => resolve(mockUser), 1000))
-    );
+    (getProfile as jest.Mock).mockReturnValue(new Promise(() => {})); // Never resolves
     render(<ProfilePage />);
     expect(document.querySelector(".animate-spin")).toBeTruthy();
   });
@@ -188,39 +121,20 @@ describe("ProfilePage Component", () => {
     render(<ProfilePage />);
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("Failed to load profile data.");
+      expect(logFrontend).toHaveBeenCalled();
     });
   });
 
-  test("renders sub-routes via outlet if present", () => {
-    (useOutlet as jest.Mock).mockReturnValue(
-      <div data-testid="outlet-content">Sub-route Content</div>
-    );
+  test("shows success toast on mount if a pending update exists in sessionStorage", async () => {
+    sessionStorage.setItem("profileUpdateToast", "Update successful!");
     render(<ProfilePage />);
-    expect(screen.getByTestId("outlet-content")).toBeTruthy();
-  });
-
-  test("shows success toast on mount if a pending update exists", async () => {
-    (window.sessionStorage.getItem as jest.Mock).mockReturnValue("Last name updated successfully.");
-    render(<ProfilePage />);
-    expect(toast.success).toHaveBeenCalledWith("Last name updated successfully.");
+    expect(toast.success).toHaveBeenCalledWith("Update successful!");
+    expect(sessionStorage.getItem("profileUpdateToast")).toBeNull();
   });
 
   // -------------------------------------------------------------------------
   // Editing fields
   // -------------------------------------------------------------------------
-
-  test("cancels editing when the X button is clicked", async () => {
-    render(<ProfilePage />);
-    await screen.findByText("John Doe");
-
-    const firstNameEdit = screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"));
-    if (firstNameEdit) fireEvent.click(firstNameEdit);
-
-    const cancelButton = screen.getAllByRole("button").find(b => b.textContent?.includes("X"));
-    if (cancelButton) fireEvent.click(cancelButton);
-
-    expect(screen.queryByRole("textbox")).toBeNull();
-  });
 
   test("allows editing and saving first name successfully", async () => {
     (updateAccount as jest.Mock).mockResolvedValue({ ...mockUser, firstName: "Jane" });
@@ -228,55 +142,16 @@ describe("ProfilePage Component", () => {
     render(<ProfilePage />);
     await screen.findByText("John Doe");
 
-    const firstNameEdit = screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"));
-    if (firstNameEdit) fireEvent.click(firstNameEdit);
+    const editButtons = screen.getAllByRole("button").filter(b => b.textContent?.includes("Pencil"));
+    fireEvent.click(editButtons[0]); // First name
 
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Jane" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
+    fireEvent.click(screen.getByText("Check"));
 
     await waitFor(() => {
       expect(updateAccount).toHaveBeenCalledWith("user-123", { first_name: "Jane" });
-      expect(toast.success).toHaveBeenCalledWith("First name updated successfully.");
-    });
-  });
-
-  test("allows editing and saving last name successfully", async () => {
-    (updateAccount as jest.Mock).mockResolvedValue({ ...mockUser, lastName: "Smith" });
-
-    render(<ProfilePage />);
-    await screen.findByText("John Doe");
-
-    const editButtons = screen.getAllByRole("button").filter(b => b.textContent?.includes("Pencil"));
-    if (editButtons[1]) fireEvent.click(editButtons[1]);
-
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Smith" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(updateAccount).toHaveBeenCalledWith("user-123", { last_name: "Smith" });
-    });
-  });
-
-  test("allows editing and saving email successfully", async () => {
-    (updateAccount as jest.Mock).mockResolvedValue({ ...mockUser, email: "jane.doe@example.com" });
-
-    render(<ProfilePage />);
-    await screen.findByText("John Doe");
-
-    const editButtons = screen.getAllByRole("button").filter(b => b.textContent?.includes("Pencil"));
-    if (editButtons[2]) fireEvent.click(editButtons[2]);
-
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "jane.doe@example.com" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(updateAccount).toHaveBeenCalledWith("user-123", { email: "jane.doe@example.com" });
+      expect(toast.success).toHaveBeenCalledWith("Profile updated successfully.");
+      expect(screen.queryByRole("textbox")).toBeNull();
     });
   });
 
@@ -286,59 +161,11 @@ describe("ProfilePage Component", () => {
     render(<ProfilePage />);
     await screen.findByText("John Doe");
 
-    const firstNameEdit = screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"));
-    if (firstNameEdit) fireEvent.click(firstNameEdit);
-
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Jane" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
+    fireEvent.click(screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"))!);
+    fireEvent.click(screen.getByText("Check"));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to update firstname.");
-    });
-  });
-
-  test("disables save and cancel buttons during save operation", async () => {
-    (updateAccount as jest.Mock).mockImplementation(
-      () => new Promise(resolve => setTimeout(() => resolve({ ...mockUser }), 100))
-    );
-
-    render(<ProfilePage />);
-    await screen.findByText("John Doe");
-
-    const firstNameEdit = screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"));
-    if (firstNameEdit) fireEvent.click(firstNameEdit);
-
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Jane" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      const disabledButtons = screen.getAllByRole("button").filter(b => b.hasAttribute("disabled"));
-      expect(disabledButtons.length).toBeGreaterThan(0);
-    });
-  });
-
-  test("clears editing state after successful save", async () => {
-    (updateAccount as jest.Mock).mockResolvedValue({ ...mockUser, firstName: "Jane" });
-
-    render(<ProfilePage />);
-    await screen.findByText("John Doe");
-
-    const firstNameEdit = screen.getAllByRole("button").find(b => b.textContent?.includes("Pencil"));
-    if (firstNameEdit) fireEvent.click(firstNameEdit);
-
-    expect(screen.getByRole("textbox")).toBeTruthy();
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Jane" } });
-
-    const saveButton = screen.getAllByRole("button").find(b => b.textContent?.includes("Check"));
-    if (saveButton) fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(updateAccount).toHaveBeenCalled();
-      expect(toast.success).toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith("Failed to update firstName.");
     });
   });
 
@@ -356,17 +183,63 @@ describe("ProfilePage Component", () => {
     });
   });
 
-  test("does not allow editing email for Google accounts", async () => {
-    (isGoogleAccount as jest.Mock).mockResolvedValue({ isGoogleUser: true });
+  // -------------------------------------------------------------------------
+  // Theme switching (Auto-save)
+  // -------------------------------------------------------------------------
+
+  test("clicking Dark theme button triggers immediate auto-save and DOM update", async () => {
     render(<ProfilePage />);
+    await screen.findByText("Dark");
+
+    fireEvent.click(screen.getByText("Dark"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(updateUserPreferences).toHaveBeenCalledWith("user-123", expect.objectContaining({ theme: "dark" }));
+  });
+
+  test("syncs theme when storage_sync event is dispatched", async () => {
+    render(<ProfilePage />);
+    await screen.findByText("John Doe");
+
+    localStorage.setItem("theme", "dark");
+    fireEvent(window, new Event("storage_sync"));
+
+    // Check if the UI buttons would reflect the change (this depends on your CSS classes)
+    await waitFor(() => {
+        const darkBtn = screen.getByText("Dark").closest('button');
+        expect(darkBtn).toHaveClass('bg-primary');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Notifications toggle (Auto-save)
+  // -------------------------------------------------------------------------
+
+  test("toggling notifications triggers auto-save", async () => {
+    render(<ProfilePage />);
+    const toggle = await screen.findByRole("switch");
+    
+    fireEvent.click(toggle);
+
+    expect(updateUserPreferences).toHaveBeenCalledWith("user-123", expect.objectContaining({ 
+        notifications_enabled: false 
+    }));
+  });
+
+  test("logs error and shows toast when auto-save fails", async () => {
+    (updateUserPreferences as jest.Mock).mockRejectedValue(new Error("Sync error"));
+    render(<ProfilePage />);
+    
+    const darkBtn = await screen.findByText("Dark");
+    fireEvent.click(darkBtn);
 
     await waitFor(() => {
-      expect(screen.getByText("john.doe@example.com")).toBeTruthy();
-      expect(screen.getAllByText(/Managed by Google/i).length).toBeGreaterThan(0);
+      expect(toast.error).toHaveBeenCalledWith("Failed to sync preferences.");
+      expect(logFrontend).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining("Auto-save failed")
+      }));
     });
-
-    const editButtons = screen.getAllByRole("button").filter(b => b.textContent?.includes("Pencil"));
-    expect(editButtons.length).toBe(2); // only first name + last name
   });
 
   // -------------------------------------------------------------------------
@@ -375,286 +248,14 @@ describe("ProfilePage Component", () => {
 
   test("navigates to change password for non-Google accounts", async () => {
     render(<ProfilePage />);
-    await screen.findByText("Change Password");
-    fireEvent.click(screen.getByText("Change Password"));
+    const btn = await screen.findByText("Change Password");
+    fireEvent.click(btn);
     expect(mockNavigate).toHaveBeenCalledWith("changePassword");
   });
 
-  // -------------------------------------------------------------------------
-  // Preferences loading
-  // -------------------------------------------------------------------------
-
-  test("calls getUserPreferences with the correct user ID on mount", async () => {
+  test("renders sub-routes via outlet if present", () => {
+    (useOutlet as jest.Mock).mockReturnValue(<div data-testid="outlet">Sub-route</div>);
     render(<ProfilePage />);
-    await screen.findByText("John Doe");
-    await waitFor(() => {
-      expect(getUserPreferences).toHaveBeenCalledWith("user-123");
-    });
-  });
-
-  test("falls back to default preferences when getUserPreferences fails", async () => {
-    (getUserPreferences as jest.Mock).mockRejectedValue(new Error("404"));
-    render(<ProfilePage />);
-    // Page should still render without crashing
-    await waitFor(() => {
-      expect(screen.getByText("John Doe")).toBeTruthy();
-    });
-  });
-
-  test("does not show error toast when preferences fetch silently fails", async () => {
-    (getUserPreferences as jest.Mock).mockRejectedValue(new Error("404"));
-    render(<ProfilePage />);
-    await waitFor(() => {
-      expect(screen.getByText("John Doe")).toBeTruthy();
-    });
-    // toast.error should only be called for profile failures, not preferences
-    expect(toast.error).not.toHaveBeenCalled();
-  });
-
-  test("renders Preferences section heading", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      expect(screen.getByText("Preferences")).toBeTruthy();
-    });
-  });
-
-  test("displays 'Enable email notifications' label", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      expect(screen.getByText("Enable email notifications")).toBeTruthy();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Theme switching
-  // -------------------------------------------------------------------------
-
-  test("renders Light and Dark theme buttons", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      expect(screen.getByText("Light")).toBeTruthy();
-      expect(screen.getByText("Dark")).toBeTruthy();
-    });
-  });
-
-  test("clicking Dark theme button changes preference state", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-
-    // After clicking Dark, the Save Preferences button should become enabled
-    // because preferences.theme ("dark") !== savedPreferences.theme ("light")
-    await waitFor(() => {
-      const saveBtn = screen.getByText("Save Preferences");
-      expect(saveBtn.closest("button")).not.toBeDisabled();
-    });
-  });
-
-  test("clicking Light theme button when already light keeps Save button disabled", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Light")).toBeTruthy());
-
-    // Click Light when already light — no change
-    fireEvent.click(screen.getByText("Light"));
-
-    const saveBtn = screen.getByText("Save Preferences");
-    expect(saveBtn.closest("button")).toBeDisabled();
-  });
-
-  // -------------------------------------------------------------------------
-  // Notifications toggle
-  // -------------------------------------------------------------------------
-
-  test("notifications toggle is rendered as a switch", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      const toggle = screen.getByRole("switch");
-      expect(toggle).toBeTruthy();
-    });
-  });
-
-  test("notifications toggle reflects initial enabled state", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      const toggle = screen.getByRole("switch");
-      expect(toggle.getAttribute("aria-checked")).toBe("true");
-    });
-  });
-
-  test("toggling notifications enables the Save Preferences button", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
-
-    fireEvent.click(screen.getByRole("switch"));
-
-    await waitFor(() => {
-      const saveBtn = screen.getByText("Save Preferences");
-      expect(saveBtn.closest("button")).not.toBeDisabled();
-    });
-  });
-
-  test("notifications toggle reflects disabled initial state", async () => {
-    (getUserPreferences as jest.Mock).mockResolvedValue({
-      theme: "light",
-      notifications_enabled: false,
-    });
-    render(<ProfilePage />);
-    await waitFor(() => {
-      const toggle = screen.getByRole("switch");
-      expect(toggle.getAttribute("aria-checked")).toBe("false");
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Save Preferences button state
-  // -------------------------------------------------------------------------
-
-  test("Save Preferences button is disabled when no preferences changed", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => {
-      const saveBtn = screen.getByText("Save Preferences");
-      expect(saveBtn.closest("button")).toBeDisabled();
-    });
-  });
-
-  test("Save Preferences button is enabled after changing theme to dark", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Save Preferences").closest("button")).not.toBeDisabled();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Saving preferences
-  // -------------------------------------------------------------------------
-
-  test("calls updateUserPreferences with correct args when Save Preferences is clicked", async () => {
-    (updateUserPreferences as jest.Mock).mockResolvedValue({
-      theme: "dark",
-      notifications_enabled: true,
-    });
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Save Preferences").closest("button")).not.toBeDisabled();
-    });
-
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    await waitFor(() => {
-      expect(updateUserPreferences).toHaveBeenCalledWith(
-        "user-123",
-        { theme: "dark", notifications_enabled: true }
-      );
-    });
-  });
-
-  test("shows success toast after saving preferences", async () => {
-    (updateUserPreferences as jest.Mock).mockResolvedValue({
-      theme: "dark",
-      notifications_enabled: true,
-    });
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("Preferences saved.");
-    });
-  });
-
-  test("shows error toast when saving preferences fails", async () => {
-    (updateUserPreferences as jest.Mock).mockRejectedValue(new Error("Server error"));
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to save preferences.");
-    });
-  });
-
-  test("Save Preferences button is disabled again after successful save", async () => {
-    (updateUserPreferences as jest.Mock).mockResolvedValue({
-      theme: "dark",
-      notifications_enabled: true,
-    });
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("Preferences saved.");
-    });
-
-    // savedPreferences is updated to match preferences — button should be disabled again
-    await waitFor(() => {
-      expect(screen.getByText("Save Preferences").closest("button")).toBeDisabled();
-    });
-  });
-
-  test("disables Save Preferences button while saving is in progress", async () => {
-    (updateUserPreferences as jest.Mock).mockImplementation(
-      () => new Promise(resolve => setTimeout(() => resolve({ theme: "dark", notifications_enabled: true }), 200))
-    );
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Dark")).toBeTruthy());
-
-    fireEvent.click(screen.getByText("Dark"));
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    // During the async save the button should be disabled
-    await waitFor(() => {
-      expect(screen.getByText("Save Preferences").closest("button")).toBeDisabled();
-    });
-  });
-
-  test("does not call updateUserPreferences when preferences unchanged", async () => {
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByText("Save Preferences")).toBeTruthy());
-
-    // Button is disabled — clicking it should not trigger the API call
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    expect(updateUserPreferences).not.toHaveBeenCalled();
-  });
-
-  test("saving notifications-only preference change calls updateUserPreferences", async () => {
-    (updateUserPreferences as jest.Mock).mockResolvedValue({
-      theme: "light",
-      notifications_enabled: false,
-    });
-
-    render(<ProfilePage />);
-    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
-
-    fireEvent.click(screen.getByRole("switch"));
-    fireEvent.click(screen.getByText("Save Preferences"));
-
-    await waitFor(() => {
-      expect(updateUserPreferences).toHaveBeenCalledWith(
-        "user-123",
-        { theme: "light", notifications_enabled: false }
-      );
-    });
+    expect(screen.getByTestId("outlet")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## 📝 Description

This PR add a themes switching button in the user options dropdown and removes the save button from the user preference section of the **Profile Page**, and makes those save automatically.

I ensured that the selected theme is synced up on both the user dropdown and the **Profile Page** (if you select a different theme from the user dropdown and you are currently on the **Profile Page**, it should automatically switch there as well, and vice versa).

## 🔧 Changes Made

List all major updates or modifications:

Added new `DropdownMenuSub` to `NavUser.tsx` corresponding to the themes
Removed **Save Preferences** button from `ProfilePage.tsx`.
Updated `NavUser.tsx` and `ProfilePage.tsx` to ensure that they sync up the user's selected theme.

## 🎯 Related Issues

Closes #363 

## ✅ Checklist

Before requesting review, confirm the following:

 - [x] My code follows the project’s style guidelines
 - [x] I’ve performed a self-review of my own code
 - [x] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [x]  I’ve added or updated tests if applicable
 - [x] New and existing tests pass locally
 - [x] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

<img width="384" height="224" alt="image" src="https://github.com/user-attachments/assets/8dd645f3-b09b-4f42-b7c5-e1bbcc878de7" />
<img width="361" height="220" alt="image" src="https://github.com/user-attachments/assets/0224e48b-34d3-4b23-be68-f990402221b5" />
<img width="1644" height="898" alt="image" src="https://github.com/user-attachments/assets/085d4841-0009-4d85-8770-e8efd6d42547" />

## 💬 Additional Notes

N/A
