### PR TITLE
Feature/337 delete algotime leaderboard

### DIFF
--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -731,3 +731,38 @@ def get_all_algotime_entries_export(response: Response, db: Annotated[Session, D
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to export AlgoTime leaderboard entries."
         )
+
+
+@leaderboards_router.delete("/algotime/reset")
+def reset_algotime_leaderboard(
+        response: Response,
+        db: Annotated[Session, Depends(get_db)],
+):
+    logger.info("=== DELETE /leaderboards/algotime/reset ===")
+    _set_no_cache_headers(response)
+
+    try:
+        deleted = db.query(AlgoTimeLeaderboardEntry).delete(synchronize_session=False)
+        db.commit()
+
+        logger.info(f"Reset AlgoTime leaderboard: deleted {deleted} entries.")
+
+        track_custom_event(
+            user_id="anonymous",
+            event_name="algotime_leaderboard_reset",
+            properties={"entries_deleted": deleted}
+        )
+
+        return {
+            "message": "AlgoTime leaderboard successfully cleared.",
+            "entriesDeleted": deleted,
+        }
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("FATAL error while resetting AlgoTime leaderboard.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reset AlgoTime leaderboard."
+        )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -26,6 +26,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from logging_config import setup_logging
 from services.competition_cleanup import cleanup_ended_competitions
+from services.algotime_cleanup import cleanup_ended_algotime_sessions
 from services.posthog_analytics import init_posthog, track_api_call, shutdown_posthog
 from services.email_scheduler import run_scheduled_emails
 from contextlib import asynccontextmanager
@@ -53,6 +54,7 @@ async def lifespan(app: FastAPI):
     scheduler = AsyncIOScheduler()
     scheduler.add_job(run_scheduled_emails, "interval", minutes=1, id="email_scheduler")
     scheduler.add_job(cleanup_ended_competitions, "interval", hours=1, id="competition_cleanup")
+    scheduler.add_job(cleanup_ended_algotime_sessions, "interval", hours=1, id="algotime_cleanup")
     scheduler.start()
     print("✓ Email scheduler started (polling every 60s)")
 

--- a/backend/src/services/algotime_cleanup.py
+++ b/backend/src/services/algotime_cleanup.py
@@ -1,0 +1,95 @@
+"""
+algotime_cleanup.py
+
+Background service that automatically purges QuestionInstance rows (and their
+cascaded children: UserQuestionInstance, Submission, MostRecentSubmission) for
+AlgoTime sessions whose event_end_date has passed.
+
+Leaderboard entries (AlgoTimeLeaderboardEntry) are intentionally left intact
+as they are cumulative across sessions and are only reset manually via the
+DELETE /leaderboards/algotime/reset endpoint at end of semester.
+
+Scheduled to run every hour from main.py.
+Similar to competition_cleanup.py
+"""
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from database_operations.database import get_db
+from models.schema import BaseEvent, AlgoTimeSession, QuestionInstance
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_ended_algotime_sessions() -> None:
+    """
+    Finds all AlgoTime sessions that have ended and deletes their QuestionInstance rows.
+
+    Cascade chain (defined in schema.py ForeignKeys):
+        QuestionInstance (deleted here)
+            └── UserQuestionInstance     ON DELETE CASCADE
+                    ├── Submission            ON DELETE CASCADE
+                    └── MostRecentSubmission  ON DELETE CASCADE
+
+    Safe to run repeatedly — if a session was already cleaned up, the query
+    returns no rows and nothing happens.
+    """
+    db: Session = next(get_db())
+
+    try:
+        now = datetime.now(timezone.utc)
+
+        ended_event_ids: list[int] = (
+            db.query(BaseEvent.event_id)
+            .join(AlgoTimeSession, AlgoTimeSession.event_id == BaseEvent.event_id)
+            .filter(BaseEvent.event_end_date < now)
+            .all()
+        )
+
+        if not ended_event_ids:
+            logger.debug("AlgoTime cleanup: no ended sessions found.")
+            return
+
+        ended_event_ids = [row.event_id for row in ended_event_ids]
+
+        instances_to_delete = (
+            db.query(QuestionInstance)
+            .filter(QuestionInstance.event_id.in_(ended_event_ids))
+            .count()
+        )
+
+        if instances_to_delete == 0:
+            logger.debug(
+                "AlgoTime cleanup: ended sessions found %s, "
+                "but QuestionInstances already cleaned up.",
+                ended_event_ids,
+            )
+            return
+
+        deleted = (
+            db.query(QuestionInstance)
+            .filter(QuestionInstance.event_id.in_(ended_event_ids))
+            .delete(synchronize_session=False)
+        )
+
+        db.commit()
+
+        logger.info(
+            "AlgoTime cleanup: deleted %d QuestionInstance row(s) "
+            "across event_ids %s. Cascaded children (UserQuestionInstance, "
+            "Submission, MostRecentSubmission) removed by DB.",
+            deleted,
+            ended_event_ids,
+        )
+
+    except SQLAlchemyError as e:
+        db.rollback()
+        logger.error("AlgoTime cleanup: database error during cleanup: %s", e)
+    except Exception as e:
+        db.rollback()
+        logger.error("AlgoTime cleanup: unexpected error: %s", e)
+    finally:
+        db.close()

--- a/backend/tests/test_algotime_cleanup.py
+++ b/backend/tests/test_algotime_cleanup.py
@@ -1,0 +1,104 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import SQLAlchemyError
+import sys
+import os
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+
+class TestAlgoTimeCleanup:
+
+    @staticmethod
+    def _make_event_row(event_id: int):
+        row = MagicMock()
+        row.event_id = event_id
+        return row
+
+    @staticmethod
+    def _setup_db(mock_db, ended_rows, qi_count, deleted=None):
+        mock_db.query.return_value.join.return_value \
+               .filter.return_value.all.return_value = ended_rows
+
+        mock_db.query.return_value.filter.return_value \
+               .count.return_value = qi_count
+
+        mock_db.query.return_value.filter.return_value \
+               .delete.return_value = deleted if deleted is not None else qi_count
+
+    @patch("src.services.algotime_cleanup.get_db")
+    def test_no_ended_sessions_returns_early(self, mock_get_db):
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db])
+
+        mock_db.query.return_value.join.return_value \
+               .filter.return_value.all.return_value = []
+
+        from src.services.algotime_cleanup import cleanup_ended_algotime_sessions
+        cleanup_ended_algotime_sessions()
+
+        mock_db.commit.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @patch("src.services.algotime_cleanup.get_db")
+    def test_already_cleaned_skips_delete(self, mock_get_db):
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db])
+
+        ended_rows = [self._make_event_row(1)]
+        self._setup_db(mock_db, ended_rows, qi_count=0)
+
+        from src.services.algotime_cleanup import cleanup_ended_algotime_sessions
+        cleanup_ended_algotime_sessions()
+
+        mock_db.commit.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @patch("src.services.algotime_cleanup.get_db")
+    def test_deletes_question_instances_and_commits(self, mock_get_db):
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db])
+
+        ended_rows = [self._make_event_row(1)]
+        self._setup_db(mock_db, ended_rows, qi_count=3, deleted=3)
+
+        from src.services.algotime_cleanup import cleanup_ended_algotime_sessions
+        cleanup_ended_algotime_sessions()
+
+        mock_db.commit.assert_called_once()
+        mock_db.rollback.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @patch("src.services.algotime_cleanup.get_db")
+    def test_sqlalchemy_error_triggers_rollback(self, mock_get_db):
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db])
+
+        ended_rows = [self._make_event_row(1)]
+        mock_db.query.return_value.join.return_value \
+               .filter.return_value.all.return_value = ended_rows
+        mock_db.query.return_value.filter.return_value \
+               .count.return_value = 2
+        mock_db.query.return_value.filter.return_value \
+               .delete.side_effect = SQLAlchemyError("connection lost")
+
+        from src.services.algotime_cleanup import cleanup_ended_algotime_sessions
+        cleanup_ended_algotime_sessions()
+
+        mock_db.rollback.assert_called_once()
+        mock_db.commit.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @patch("src.services.algotime_cleanup.get_db")
+    def test_db_always_closed_on_error(self, mock_get_db):
+        mock_db = MagicMock()
+        mock_get_db.return_value = iter([mock_db])
+
+        mock_db.query.side_effect = Exception("fatal")
+
+        from src.services.algotime_cleanup import cleanup_ended_algotime_sessions
+        cleanup_ended_algotime_sessions()
+
+        mock_db.close.assert_called_once()

--- a/backend/tests/test_leaderboard_api.py
+++ b/backend/tests/test_leaderboard_api.py
@@ -18,6 +18,7 @@ from src.endpoints.leaderboards_api import (
     get_all_competition_entries,
     _set_no_cache_headers,
     _set_short_cache_headers,
+    reset_algotime_leaderboard
 )
 
 
@@ -1235,3 +1236,36 @@ class TestGetLeaderboardsAdditional:
 
         assert result["competitions"][0]["id"] == "42"
         assert isinstance(result["competitions"][0]["id"], str)
+
+class TestResetAlgoTimeLeaderboard:
+
+    def test_successful_reset_returns_count(self, mock_db, mock_response):
+        mock_db.query.return_value.delete.return_value = 5
+
+        result = reset_algotime_leaderboard(mock_response, mock_db)
+
+        assert result["entriesDeleted"] == 5
+        assert "successfully cleared" in result["message"]
+
+    def test_reset_with_zero_entries(self, mock_db, mock_response):
+        mock_db.query.return_value.delete.return_value = 0
+
+        result = reset_algotime_leaderboard(mock_response, mock_db)
+
+        assert result["entriesDeleted"] == 0
+
+    def test_commits_after_delete(self, mock_db, mock_response):
+        mock_db.query.return_value.delete.return_value = 3
+
+        reset_algotime_leaderboard(mock_response, mock_db)
+
+        mock_db.commit.assert_called_once()
+
+    def test_database_error_raises_500(self, mock_db, mock_response):
+        mock_db.query.side_effect = Exception("DB down")
+
+        with pytest.raises(HTTPException) as exc_info:
+            reset_algotime_leaderboard(mock_response, mock_db)
+
+        assert exc_info.value.status_code == 500
+        assert "Failed to reset" in exc_info.value.detail

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -376,3 +376,15 @@ export async function getAllAlgoTimeEntriesForExport(): Promise<AlgoTimeEntry[]>
         throw err;
     }
 }
+
+export async function resetAlgoTimeLeaderboard(): Promise<{ message: string; entriesDeleted: number }> {
+    try {
+        const response = await axiosClient.delete<{ message: string; entriesDeleted: number }>(
+            "/leaderboards/algotime/reset"
+        );
+        return response.data;
+    } catch (err) {
+        console.error("Error resetting AlgoTime leaderboard:", err);
+        throw err;
+    }
+}

--- a/frontend/src/views/admin/ManageAlgotimeSessionsPage.tsx
+++ b/frontend/src/views/admin/ManageAlgotimeSessionsPage.tsx
@@ -29,6 +29,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {EditAlgoTimeSessionDialog} from "@/components/algotime/EditAlgotimeDialog"
+import { resetAlgoTimeLeaderboard } from "@/api/LeaderboardsAPI";
 
 export default function ManageAlgotimeSessionsPage() {
   const [searchQuery, setSearchQuery] = useState("");
@@ -162,6 +163,45 @@ export default function ManageAlgotimeSessionsPage() {
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+        <div className="sm:ml-auto">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button  className="gap-2 text-destructive bg-destructive text-white font-bold hover:bg-destructive/40 sm:w-auto w-full">
+                <Trash className="h-4 w-4" />
+                Reset Leaderboard
+              </Button>
+            </AlertDialogTrigger>
+
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Reset AlgoTime Leaderboard?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will PERMANENTLY delete all leaderboard entries. This is
+                  typically done at the end of a semester and CANNOT be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-white hover:bg-destructive/90"
+                  onClick={async () => {
+                    try {
+                      const result = await resetAlgoTimeLeaderboard();
+                      toast.success(
+                        `Leaderboard reset successfully — ${result.entriesDeleted} ${result.entriesDeleted === 1 ? "entry" : "entries"} deleted.`
+                      );
+                    } catch {
+                      toast.error("Failed to reset the leaderboard.");
+                    }
+                  }}
+                >
+                  Reset
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">

--- a/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
+++ b/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
@@ -44,6 +44,15 @@ jest.mock('@/components/algotime/EditAlgotimeDialog', () => ({
   EditAlgoTimeSessionDialog: () => null,
 }));
 
+jest.mock('@/lib/axiosClient', () => ({
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
 const mockSessions = [
   {
     id: 1,

--- a/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
+++ b/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
@@ -3,6 +3,7 @@ import ManageAlgotimeSessionsPage from '../src/views/admin/ManageAlgotimeSession
 import { getAllAlgotimeSessions,deleteAlgotime } from '../src/api/AlgotimeAPI';
 import { toast } from 'sonner';
 import { logFrontend } from '../src/api/LoggerAPI';
+import { resetAlgoTimeLeaderboard } from '../src/api/LeaderboardsAPI';
 
 
 const mockNavigate = jest.fn();
@@ -15,6 +16,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('sonner', () => ({
   toast: {
     error: jest.fn(),
+    success: jest.fn(),
   },
 }));
 
@@ -216,4 +218,48 @@ describe('ManageAlgotimeSessionsPage', () => {
     expect(screen.getByText('Winter AlgoTime 2025')).toBeInTheDocument();
   });
 
+  test('renders reset leaderboard button', async () => {
+    render(<ManageAlgotimeSessionsPage />);
+  
+    await waitFor(() => {
+      expect(screen.getByText('Reset Leaderboard')).toBeInTheDocument();
+    });
+  });
+  
+  test('calls resetAlgoTimeLeaderboard and shows success toast on confirm', async () => {
+    (resetAlgoTimeLeaderboard as jest.Mock).mockResolvedValue({ entriesDeleted: 5, message: 'success' });
+  
+    render(<ManageAlgotimeSessionsPage />);
+  
+    await waitFor(() => {
+      expect(screen.getByText('Reset Leaderboard')).toBeInTheDocument();
+    });
+  
+    fireEvent.click(screen.getByText('Reset Leaderboard'));
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+  
+    await waitFor(() => {
+      expect(resetAlgoTimeLeaderboard).toHaveBeenCalledTimes(1);
+      expect(toast.success).toHaveBeenCalledWith(
+        'Leaderboard reset successfully — 5 entries deleted.'
+      );
+    });
+  });
+  
+  test('shows error toast when reset fails', async () => {
+    (resetAlgoTimeLeaderboard as jest.Mock).mockRejectedValue(new Error('Server error'));
+  
+    render(<ManageAlgotimeSessionsPage />);
+  
+    await waitFor(() => {
+      expect(screen.getByText('Reset Leaderboard')).toBeInTheDocument();
+    });
+  
+    fireEvent.click(screen.getByText('Reset Leaderboard'));
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+  
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Failed to reset the leaderboard.');
+    });
+  });
 });

--- a/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
+++ b/frontend/tests/ManageAlgotimeSessionsPage.test.tsx
@@ -53,6 +53,10 @@ jest.mock('@/lib/axiosClient', () => ({
   },
 }));
 
+jest.mock('@/api/LeaderboardsAPI', () => ({
+  resetAlgoTimeLeaderboard: jest.fn(),
+}));
+
 const mockSessions = [
   {
     id: 1,


### PR DESCRIPTION
## 📝 Description

> This PR adds the cleaup file for algotime after every algotime sessions to cleanup all submissions and user question instances. It also created the delete button for leaderboards for algotime

## 🔧 Changes Made

List all major updates or modifications:

Added reset leaderboard and cleanup_algotime function
Updated manageAlgotimeSessionsPage and tests


## 🎯 Related Issues

Closes #337 
Closes #371 


## ✅ Checklist

Before requesting review, confirm the following:

 - [x] My code follows the project’s style guidelines
 - [x] I’ve performed a self-review of my own code
 - [x] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [x]  I’ve added or updated tests if applicable
 - [x] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

Add screenshots or GIFs if your changes affect the UI.
<img width="1077" height="483" alt="Screenshot 2026-03-20 at 3 29 19 AM" src="https://github.com/user-attachments/assets/8106e583-0757-475f-8772-9acdfd4b0e61" />


## 💬 Additional Notes

Any extra context, caveats, or follow-up tasks:

