### PR TITLE
refactor: remove unused getRiddles & getTestcases function in Questio…

### DIFF
--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -640,7 +640,6 @@ def get_algotime_leaderboard(
         result = [
             {
                 "entryId": entry.algotime_leaderboard_entry_id,
-                "algoTimeSeriesId": entry.algotime_series_id,
                 "name": display_name(entry),
                 "userId": entry.user_id,
                 "totalScore": entry.total_score,

--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -666,7 +666,7 @@ def get_algotime_leaderboard(
                 "page": page,
                 "search": search,
                 "is_authenticated": current_user_id is not None,
-                "unique_series": len({e.algotime_series_id for e in all_entries}),
+                
             }
         )
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -180,4 +180,4 @@ except Exception:
 # Run server
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="https://thinkly-production.up.railway.app/",  port=int(os.getenv("PORT", 8000)), reload=True, reload_excludes=["logs", "*.log", "__pycache__", "./*.db", "./*.sqlite"])
+    uvicorn.run("main:app", host="0.0.0.0",  port=int(os.getenv("PORT", 8000)), reload=True, reload_excludes=["logs", "*.log", "__pycache__", "./*.db", "./*.sqlite"])

--- a/backend/src/models/schema.py
+++ b/backend/src/models/schema.py
@@ -129,9 +129,6 @@ class AlgoTimeSeries(Base):
     algotime_series_name: Mapped[str] = mapped_column(unique=True)
     algotime_sessions: Mapped[List[AlgoTimeSession]] = relationship('AlgoTimeSession', back_populates='algotime_series',
                                                                     uselist=True)
-    algotime_leaderboard_entries: Mapped[List[AlgoTimeLeaderboardEntry]] = relationship('AlgoTimeLeaderboardEntry',
-                                                                                        back_populates='algotime_series',
-                                                                                        uselist=True)
 
 
 class AlgoTimeSession(Base):
@@ -142,9 +139,10 @@ class AlgoTimeSession(Base):
         ForeignKey('algotime_series.algotime_series_id', ondelete=ON_DELETE_SET_NULL))
 
     base_event: Mapped[BaseEvent] = relationship('BaseEvent', back_populates='algotime', uselist=False)
+    
+    # ADDED THIS LINE BACK IN to fix the mapper initialization error
     algotime_series: Mapped[Optional[AlgoTimeSeries]] = relationship('AlgoTimeSeries',
                                                                      back_populates='algotime_sessions', uselist=False)
-
 
 question_tag = Table(
     'question_tag', Base.metadata,
@@ -338,15 +336,17 @@ class AlgoTimeLeaderboardEntry(Base):
     total_time: Mapped[int] = mapped_column()
     last_updated: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(timezone.utc),
                                                    onupdate=datetime.now(timezone.utc))
-    algotime_series: Mapped[AlgoTimeSeries] = relationship('AlgoTimeSeries',
-                                                           back_populates='algotime_leaderboard_entries', uselist=False)
+    
+
     user_account: Mapped[Optional[UserAccount]] = relationship('UserAccount',
                                                                back_populates='algotime_leaderboard_entries',
                                                                uselist=False)
 
-    __table_args__ = (
-        UniqueConstraint('algotime_series_id', 'user_id', name='uix_algotime_user'),
-    )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.calculated_rank = None
+
+
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/backend/src/models/schema.py
+++ b/backend/src/models/schema.py
@@ -331,8 +331,6 @@ class AlgoTimeLeaderboardEntry(Base):
     __tablename__ = 'algotime_leaderboard_entry'
 
     algotime_leaderboard_entry_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    algotime_series_id: Mapped[int] = mapped_column(
-        ForeignKey('algotime_series.algotime_series_id', ondelete='CASCADE'))
     name: Mapped[str] = mapped_column()
     user_id: Mapped[Optional[int]] = mapped_column(ForeignKey(FK_USER_ACCOUNT_USER_ID, ondelete=ON_DELETE_SET_NULL))
     total_score: Mapped[int] = mapped_column()

--- a/backend/src/models/schema.py
+++ b/backend/src/models/schema.py
@@ -320,9 +320,7 @@ class CompetitionLeaderboardEntry(Base):
         UniqueConstraint('competition_id', 'user_id', name='uix_competition_user'),
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.calculated_rank = None
+
 
 
 class AlgoTimeLeaderboardEntry(Base):
@@ -342,9 +340,6 @@ class AlgoTimeLeaderboardEntry(Base):
                                                                back_populates='algotime_leaderboard_entries',
                                                                uselist=False)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.calculated_rank = None
 
 
 

--- a/backend/tests/test_leaderboard_api.py
+++ b/backend/tests/test_leaderboard_api.py
@@ -615,11 +615,10 @@ class TestGetAlgoTimeEndpoints:
         row = result["entries"][0]
 
         assert set(row.keys()) == {
-            "entryId", "algoTimeSeriesId", "name", "userId",
+            "entryId", "name", "userId",
             "totalScore", "problemsSolved", "totalTime", "rank", "lastUpdated"
         }
         assert row["entryId"] == 10
-        assert row["algoTimeSeriesId"] == 7
         assert row["name"] == "First1 Last1"
         assert row["userId"] == 1
         assert row["totalScore"] == 100
@@ -677,13 +676,6 @@ class TestGetAlgoTimeEndpoints:
 
         assert len(result["entries"]) == 2
 
-    def test_paginated_algotime_series_id_preserved(self, mock_db, mock_response):
-        entry = self._make_algo_entry(1, 50, series_id=99)
-        mock_db.query.return_value.all.return_value = [entry]
-
-        result = get_algotime_leaderboard(mock_response, mock_db, **_ALGOTIME_DEFAULTS)
-
-        assert result["entries"][0]["algoTimeSeriesId"] == 99
 
     def test_paginated_last_updated_is_iso_string(self, mock_db, mock_response):
         ts = datetime(2025, 12, 31, 23, 59, 59, tzinfo=timezone.utc)

--- a/backend/tests/test_leaderboard_api.py
+++ b/backend/tests/test_leaderboard_api.py
@@ -578,7 +578,6 @@ class TestGetAlgoTimeEndpoints:
     def _make_algo_entry(self, user_id: int, score: int, series_id: int = 1, last_updated=None):
         entry = Mock()
         entry.algotime_leaderboard_entry_id = user_id * 10
-        entry.algotime_series_id = series_id
         entry.user_id = user_id
         entry.name = f"User {user_id}"
         entry.total_score = score
@@ -1033,7 +1032,6 @@ class TestGetCurrentAlgoTimeLeaderboard:
     def _make_algo_entry(self, user_id, score, series_id=1):
         entry = Mock()
         entry.algotime_leaderboard_entry_id = user_id * 10
-        entry.algotime_series_id = series_id
         entry.user_id = user_id
         entry.name = f"User {user_id}"
         entry.total_score = score

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -51,7 +51,6 @@ interface CurrentCompetitionResponse {
 
 export interface AlgoTimeEntry {
     entryId: number;
-    seriesId: number;
     name: string;
     user_id: number;
     total_score: number;
@@ -332,6 +331,7 @@ export async function getAlgoTimeEntries(
             pageSize: response.data.page_size,
             entries: response.data.entries.map((e) => ({
                 entryId: e.entryId,
+
                 name: e.name,
                 user_id: e.userId,
                 total_score: e.totalScore,

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -313,7 +313,6 @@ export async function getAlgoTimeEntries(
             page_size: number;
             entries: Array<{
                 entryId: number;
-                algoTimeSeriesId: number;
                 name: string;
                 userId: number;
                 totalScore: number;
@@ -333,7 +332,6 @@ export async function getAlgoTimeEntries(
             pageSize: response.data.page_size,
             entries: response.data.entries.map((e) => ({
                 entryId: e.entryId,
-                seriesId: e.algoTimeSeriesId,
                 name: e.name,
                 user_id: e.userId,
                 total_score: e.totalScore,

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -361,7 +361,6 @@ export async function getAllAlgoTimeEntriesForExport(): Promise<AlgoTimeEntry[]>
 
         return response.data.map((e) => ({
             entryId: e.entryId,
-            seriesId: 0,
             name: e.name,
             user_id: e.userId,
             total_score: e.totalScore,

--- a/frontend/src/api/QuestionsAPI.tsx
+++ b/frontend/src/api/QuestionsAPI.tsx
@@ -5,12 +5,11 @@ import type {
   QuestionsPageParams,
   QuestionsPageResult,
   QuestionsResponse,
-  RiddlesResponse,
   TestCase,
   LanguageSpecificProperties
 } from "@/types/questions/QuestionPagination.type";
 import { logFrontend } from "./LoggerAPI";
-import type { Riddle } from "@/types/riddle/Riddle.type";
+
 
 const DEFAULT_PAGE_SIZE = 100;
 

--- a/frontend/src/api/QuestionsAPI.tsx
+++ b/frontend/src/api/QuestionsAPI.tsx
@@ -163,66 +163,6 @@ export async function deleteQuestion(questionId: number): Promise<void> {
   await deleteQuestions([questionId]);
 }
 
-export async function getRiddles(): Promise<Riddle[]> {
-  try {
-    const firstPage = await axiosClient.get<RiddlesResponse>(
-      "/questions/get-all-riddles",
-      { params: { page: 1, page_size: DEFAULT_PAGE_SIZE } },
-    );
-
-    let riddleItems = [...firstPage.data.items];
-    const totalPages = Math.ceil(firstPage.data.total / firstPage.data.page_size);
-
-    for (let page = 2; page <= totalPages; page += 1) {
-      const nextPage = await axiosClient.get<RiddlesResponse>(
-        "/questions/get-all-riddles",
-        { params: { page, page_size: firstPage.data.page_size } },
-      );
-      riddleItems = [...riddleItems, ...nextPage.data.items];
-    }
-
-    return riddleItems.map((riddle) => ({
-      id: riddle.riddle_id,
-      question: riddle.riddle_question,
-      answer: riddle.riddle_answer,
-      file: riddle.riddle_file || null,
-    }));
-  } catch (err) {
-    logFrontend({
-      level: "ERROR",
-      message: `An error occurred when fetching riddles. Reason: ${err}`,
-      component: "QuestionsAPI",
-      url: globalThis.location.href,
-      stack: (err as Error).stack,
-    })
-    throw err;
-  }
-}
-
-export async function getTestcases(
-  question_id: number,
-): Promise<TestCase[]> {
-  try {
-    const response = await axiosClient.get<
-      {
-        test_case_id: number;
-        question_id: number;
-        input_data: unknown;
-        expected_output: unknown;
-      }[]
-    >(`/questions/get-all-testcases/${question_id}`);
-
-    return response.data.map((testcase) => ({
-      test_case_id: testcase.test_case_id,
-      question_id: testcase.question_id,
-      input_data: testcase.input_data,
-      expected_output: testcase.expected_output,
-    }));
-  } catch (err) {
-    console.error("Error fetching testcases:", err);
-    throw err;
-  }
-}
 
 export async function deleteCompetition(competitionId: string): Promise<void> {
   try {

--- a/frontend/src/types/algoTime/AlgoTimeLeaderboard.type.tsx
+++ b/frontend/src/types/algoTime/AlgoTimeLeaderboard.type.tsx
@@ -1,6 +1,5 @@
 export type AlgoTimeLeaderboardBackendEntry = {
     entryId: number;
-    algoTimeSeriesId: number;
     name: string;
     userId: number | null;
     totalScore: number;

--- a/frontend/tests/AlgoTimeCard.test.tsx
+++ b/frontend/tests/AlgoTimeCard.test.tsx
@@ -54,7 +54,6 @@ jest.mock("xlsx", () => ({
 const makeEntries = (n: number): AlgoTimeEntry[] =>
   Array.from({ length: n }, (_, i) => ({
     entryId: i + 1,
-    seriesId: 1,
     name: `User ${i + 1}`,
     user_id: i + 1,
     total_score: 1000 - i * 10,

--- a/frontend/tests/LeaderboardsAPI.test.tsx
+++ b/frontend/tests/LeaderboardsAPI.test.tsx
@@ -534,7 +534,6 @@ describe("LeaderboardsAPI", () => {
           entries: [
             {
               entryId: 1,
-              algoTimeSeriesId: 2,
               name: "Carol",
               userId: 99,
               totalScore: 300,

--- a/frontend/tests/LeaderboardsAPI.test.tsx
+++ b/frontend/tests/LeaderboardsAPI.test.tsx
@@ -562,7 +562,6 @@ describe("LeaderboardsAPI", () => {
         entries: [
           {
             entryId: 1,
-            seriesId: 2,
             name: "Carol",
             user_id: 99,
             total_score: 300,
@@ -649,7 +648,6 @@ describe("LeaderboardsAPI", () => {
       expect(result).toEqual([
         {
           entryId: 5,
-          seriesId: 0,
           name: "Dave",
           user_id: 22,
           total_score: 500,

--- a/frontend/tests/QuestionsAPI.test.tsx
+++ b/frontend/tests/QuestionsAPI.test.tsx
@@ -3,7 +3,6 @@ import {
   getQuestionByID,
   getQuestions,
   getQuestionsPage,
-  // getRiddles,
   deleteCompetition,
   deleteQuestions,
   deleteQuestion,


### PR DESCRIPTION
# refactor: clean up unused AlgoTime series attributes and leaderboard initializations

## 📝 Description

> This PR focuses on paying down technical debt by removing unused functions, dead code, and obsolete attributes related to `algotime_series` and leaderboards. It streamlines our models and API endpoints while restoring necessary SQLAlchemy relationships to ensure database integrity.

## 🔧 Changes Made

* **Removed** unused `getRiddles` and `getTestcases` functions from `QuestionsAPI`.
* **Removed** the unused `algoTimeSeriesId`, `seriesId`, and `algotime_series_id` attributes across `AlgoTimeEntry`, export functions, and related test files (`TestGetAlgoTimeEndpoints`, `TestGetCurrentAlgoTimeLeaderboard`).
* **Removed** obsolete `__init__` methods from both `CompetitionLeaderboardEntry` and `AlgoTimeLeaderboardEntry` models.
* **Updated** and cleaned up imports within `QuestionsAPI` and various test files.
* **Fixed/Restored** the `algotime_series` relationship inside `AlgoTimeSession` to resolve mapper initialization errors.

## 🎯 Related Issues

Closes #346 


## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ] I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

*(N/A - backend logic and model refactoring only)*

## 💬 Additional Notes

This is primarily a backend cleanup and refactor. Ensure that any database migrations (if applicable) are run, though most of these changes simply drop unused ORM attributes and methods.