### PR TITLE
Update scores in leaderboard when submission is accepted  for Algo & Comp

### DIFF
--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -101,6 +101,17 @@ def calculate_rank(entries: List) -> List:
     return sorted_entries
 
 
+def _aggregate_uqi_stats(uqi_rows: List) -> tuple[int, int, int]:
+    """
+    Compute (total_score, problems_solved, total_time) from a list of
+    UserQuestionInstance rows.  Shared by both competition and AlgoTime upserts.
+    """
+    total_score = sum(row.points for row in uqi_rows if row.points is not None)
+    problems_solved = sum(1 for row in uqi_rows if row.points is not None and row.points > 0)
+    total_time = sum(row.lapse_time for row in uqi_rows if row.lapse_time is not None)
+    return total_score, problems_solved, total_time
+
+
 def get_filtered_leaderboard_entries(entries: List, current_user_id: Optional[int]) -> tuple:
     """
     Returns top 10 entries, or top 10 + current user (±1 position) if user is not in top 10.
@@ -782,9 +793,7 @@ def upsert_competition_leaderboard_entry(
             .all()
         )
 
-        total_score = sum(row.points for row in uqi_rows if row.points is not None)
-        problems_solved = sum(1 for row in uqi_rows if row.points is not None and row.points > 0)
-        total_time = sum(row.lapse_time for row in uqi_rows if row.lapse_time is not None)
+        total_score, problems_solved, total_time = _aggregate_uqi_stats(uqi_rows)
 
         # Upsert: update existing entry or create a new one
         entry = (
@@ -870,9 +879,7 @@ def upsert_algotime_leaderboard_entry(
             .all()
         )
 
-        total_score = sum(row.points for row in uqi_rows if row.points is not None)
-        problems_solved = sum(1 for row in uqi_rows if row.points is not None and row.points > 0)
-        total_time = sum(row.lapse_time for row in uqi_rows if row.lapse_time is not None)
+        total_score, problems_solved, total_time = _aggregate_uqi_stats(uqi_rows)
 
         # Upsert: update existing entry or create a new one
         entry = (

--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -784,8 +784,11 @@ def upsert_algotime_leaderboard_entry(
         )
 
         if entry:
-            entry.total_score = total_score
-            entry.problems_solved = problems_solved
+            # Never let the score decrease — guards against UQI rows being
+            # temporarily absent (e.g. race condition, cleanup lag) causing a
+            # stale recalculation to overwrite a legitimately higher score.
+            entry.total_score = max(total_score, entry.total_score)
+            entry.problems_solved = max(problems_solved, entry.problems_solved)
             entry.total_time = total_time
             entry.last_updated = datetime.now(timezone.utc)
         else:

--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -22,6 +22,11 @@ from services.posthog_analytics import track_custom_event
 class AlgoTimeEntryUpsertRequest(BaseModel):
     user_id: int
 
+
+class CompetitionEntryUpsertRequest(BaseModel):
+    user_id: int
+    competition_id: int
+
 leaderboards_router = APIRouter(tags=["Leaderboards"])
 logger = logging.getLogger(__name__)
 
@@ -738,6 +743,99 @@ def get_all_algotime_entries_export(response: Response, db: Annotated[Session, D
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to export AlgoTime leaderboard entries."
+        )
+
+
+@leaderboards_router.put("/competitions/entry")
+def upsert_competition_leaderboard_entry(
+        request: CompetitionEntryUpsertRequest,
+        response: Response,
+        db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Recalculates and upserts the competition leaderboard entry for a given user.
+    Aggregates all points and lapse_time from the user's UserQuestionInstance rows
+    that belong to the specified competition.
+    Called after each accepted submission during a competition.
+    """
+    logger.info(f"=== PUT /leaderboards/competitions/entry, user_id={request.user_id}, competition_id={request.competition_id} ===")
+    _set_no_cache_headers(response)
+
+    try:
+        user = db.query(UserAccount).filter(UserAccount.user_id == request.user_id).first()
+        if not user:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+        competition = db.query(Competition).filter(Competition.event_id == request.competition_id).first()
+        if not competition:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Competition not found.")
+
+        # Aggregate all points/time for this user in this specific competition
+        uqi_rows = (
+            db.query(UserQuestionInstance)
+            .join(QuestionInstance,
+                  UserQuestionInstance.question_instance_id == QuestionInstance.question_instance_id)
+            .filter(
+                UserQuestionInstance.user_id == request.user_id,
+                QuestionInstance.event_id == request.competition_id,
+            )
+            .all()
+        )
+
+        total_score = sum(row.points for row in uqi_rows if row.points is not None)
+        problems_solved = sum(1 for row in uqi_rows if row.points is not None and row.points > 0)
+        total_time = sum(row.lapse_time for row in uqi_rows if row.lapse_time is not None)
+
+        # Upsert: update existing entry or create a new one
+        entry = (
+            db.query(CompetitionLeaderboardEntry)
+            .filter(
+                CompetitionLeaderboardEntry.competition_id == request.competition_id,
+                CompetitionLeaderboardEntry.user_id == request.user_id,
+            )
+            .first()
+        )
+
+        if entry:
+            entry.total_score = max(total_score, entry.total_score)
+            entry.problems_solved = max(problems_solved, entry.problems_solved)
+            entry.total_time = total_time
+        else:
+            entry = CompetitionLeaderboardEntry(
+                competition_id=request.competition_id,
+                name=f"{user.first_name} {user.last_name}",
+                user_id=request.user_id,
+                total_score=total_score,
+                problems_solved=problems_solved,
+                total_time=total_time,
+            )
+            db.add(entry)
+
+        db.commit()
+        db.refresh(entry)
+
+        logger.info(
+            f"Upserted competition entry for user {request.user_id} in competition {request.competition_id}: "
+            f"score={entry.total_score}, problems={entry.problems_solved}, time={entry.total_time}"
+        )
+
+        return {
+            "entryId": entry.competition_leaderboard_entry_id,
+            "userId": entry.user_id,
+            "competitionId": entry.competition_id,
+            "name": f"{user.first_name} {user.last_name}",
+            "totalScore": entry.total_score,
+            "problemsSolved": entry.problems_solved,
+            "totalTime": entry.total_time,
+        }
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(f"FATAL error while upserting competition entry for user {request.user_id}.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update competition leaderboard entry."
         )
 
 

--- a/backend/src/endpoints/leaderboards_api.py
+++ b/backend/src/endpoints/leaderboards_api.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import BaseModel
 from sqlalchemy import exists
 from sqlalchemy.orm import Session
 from typing import Annotated, List, Optional
@@ -7,11 +8,19 @@ from database_operations.database import get_db
 from models.schema import (
     CompetitionLeaderboardEntry,
     AlgoTimeLeaderboardEntry,
+    AlgoTimeSession,
     Competition,
-    BaseEvent
+    BaseEvent,
+    UserAccount,
+    UserQuestionInstance,
+    QuestionInstance,
 )
 import logging
 from services.posthog_analytics import track_custom_event
+
+
+class AlgoTimeEntryUpsertRequest(BaseModel):
+    user_id: int
 
 leaderboards_router = APIRouter(tags=["Leaderboards"])
 logger = logging.getLogger(__name__)
@@ -729,6 +738,92 @@ def get_all_algotime_entries_export(response: Response, db: Annotated[Session, D
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to export AlgoTime leaderboard entries."
+        )
+
+
+@leaderboards_router.put("/algotime/entry")
+def upsert_algotime_leaderboard_entry(
+        request: AlgoTimeEntryUpsertRequest,
+        response: Response,
+        db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Recalculates and upserts the AlgoTime leaderboard entry for a given user.
+    Aggregates all points and lapse_time from the user's UserQuestionInstance rows
+    that belong to AlgoTime sessions (not competitions).
+    Called after each accepted submission during an AlgoTime session.
+    """
+    logger.info(f"=== PUT /leaderboards/algotime/entry, user_id={request.user_id} ===")
+    _set_no_cache_headers(response)
+
+    try:
+        user = db.query(UserAccount).filter(UserAccount.user_id == request.user_id).first()
+        if not user:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+
+        # Aggregate all points/time for this user across all AlgoTime sessions
+        uqi_rows = (
+            db.query(UserQuestionInstance)
+            .join(QuestionInstance,
+                  UserQuestionInstance.question_instance_id == QuestionInstance.question_instance_id)
+            .join(AlgoTimeSession,
+                  QuestionInstance.event_id == AlgoTimeSession.event_id)
+            .filter(UserQuestionInstance.user_id == request.user_id)
+            .all()
+        )
+
+        total_score = sum(row.points for row in uqi_rows if row.points is not None)
+        problems_solved = sum(1 for row in uqi_rows if row.points is not None and row.points > 0)
+        total_time = sum(row.lapse_time for row in uqi_rows if row.lapse_time is not None)
+
+        # Upsert: update existing entry or create a new one
+        entry = (
+            db.query(AlgoTimeLeaderboardEntry)
+            .filter(AlgoTimeLeaderboardEntry.user_id == request.user_id)
+            .first()
+        )
+
+        if entry:
+            entry.total_score = total_score
+            entry.problems_solved = problems_solved
+            entry.total_time = total_time
+            entry.last_updated = datetime.now(timezone.utc)
+        else:
+            entry = AlgoTimeLeaderboardEntry(
+                name=f"{user.first_name} {user.last_name}",
+                user_id=request.user_id,
+                total_score=total_score,
+                problems_solved=problems_solved,
+                total_time=total_time,
+                last_updated=datetime.now(timezone.utc),
+            )
+            db.add(entry)
+
+        db.commit()
+        db.refresh(entry)
+
+        logger.info(
+            f"Upserted AlgoTime entry for user {request.user_id}: "
+            f"score={total_score}, problems={problems_solved}, time={total_time}"
+        )
+
+        return {
+            "entryId": entry.algotime_leaderboard_entry_id,
+            "userId": entry.user_id,
+            "name": f"{user.first_name} {user.last_name}",
+            "totalScore": entry.total_score,
+            "problemsSolved": entry.problems_solved,
+            "totalTime": entry.total_time,
+            "lastUpdated": entry.last_updated.isoformat(),
+        }
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(f"FATAL error while upserting AlgoTime entry for user {request.user_id}.")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update AlgoTime leaderboard entry."
         )
 
 

--- a/backend/src/endpoints/user_question_instance_api.py
+++ b/backend/src/endpoints/user_question_instance_api.py
@@ -76,10 +76,12 @@ def add_user_question_instance(
             db.add(query)
         else:
             print("updating")
-            # update if it exist
+            # update if it exists — never overwrite a non-null points value with null
+            # (prevents accidental score reset when the UQI is re-initialised on re-join)
             query.user_id = request['user_id']
             query.question_instance_id = request['question_instance_id']
-            query.points = request['points']
+            if request['points'] is not None:
+                query.points = request['points']
             query.riddle_complete = request['riddle_complete']
             query.lapse_time = request['lapse_time']
             query.attempts = request['attempts']

--- a/backend/tests/test_leaderboard_api.py
+++ b/backend/tests/test_leaderboard_api.py
@@ -18,7 +18,12 @@ from src.endpoints.leaderboards_api import (
     get_all_competition_entries,
     _set_no_cache_headers,
     _set_short_cache_headers,
-    reset_algotime_leaderboard
+    reset_algotime_leaderboard,
+    _aggregate_uqi_stats,
+    upsert_algotime_leaderboard_entry,
+    upsert_competition_leaderboard_entry,
+    AlgoTimeEntryUpsertRequest,
+    CompetitionEntryUpsertRequest,
 )
 
 
@@ -1258,4 +1263,316 @@ class TestResetAlgoTimeLeaderboard:
             reset_algotime_leaderboard(mock_response, mock_db)
 
         assert exc_info.value.status_code == 500
-        assert "Failed to reset" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_uqi_stats
+# ---------------------------------------------------------------------------
+
+def make_uqi_row(points=None, lapse_time=None):
+    row = Mock()
+    row.points = points
+    row.lapse_time = lapse_time
+    return row
+
+
+class TestAggregateUqiStats:
+
+    def test_sums_points_ignoring_none(self):
+        rows = [make_uqi_row(100), make_uqi_row(None), make_uqi_row(200)]
+        total_score, _, _ = _aggregate_uqi_stats(rows)
+        assert total_score == 300
+
+    def test_counts_problems_solved_as_nonzero_points(self):
+        rows = [make_uqi_row(100), make_uqi_row(0), make_uqi_row(None), make_uqi_row(200)]
+        _, problems_solved, _ = _aggregate_uqi_stats(rows)
+        assert problems_solved == 2
+
+    def test_sums_lapse_time_ignoring_none(self):
+        rows = [make_uqi_row(lapse_time=60), make_uqi_row(lapse_time=None), make_uqi_row(lapse_time=120)]
+        _, _, total_time = _aggregate_uqi_stats(rows)
+        assert total_time == 180
+
+    def test_empty_rows_returns_zeros(self):
+        total_score, problems_solved, total_time = _aggregate_uqi_stats([])
+        assert total_score == 0
+        assert problems_solved == 0
+        assert total_time == 0
+
+    def test_all_none_points_gives_zero_score(self):
+        rows = [make_uqi_row(None), make_uqi_row(None)]
+        total_score, problems_solved, _ = _aggregate_uqi_stats(rows)
+        assert total_score == 0
+        assert problems_solved == 0
+
+    def test_returns_tuple_of_three(self):
+        result = _aggregate_uqi_stats([])
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# upsert_algotime_leaderboard_entry
+# ---------------------------------------------------------------------------
+
+def _make_algotime_request(user_id=1):
+    return AlgoTimeEntryUpsertRequest(user_id=user_id)
+
+
+def _make_user(first="Alice", last="Smith"):
+    u = Mock()
+    u.first_name = first
+    u.last_name = last
+    return u
+
+
+def _make_algotime_entry(user_id=1, total_score=100, problems_solved=1, total_time=60):
+    e = Mock()
+    e.algotime_leaderboard_entry_id = 99
+    e.user_id = user_id
+    e.total_score = total_score
+    e.problems_solved = problems_solved
+    e.total_time = total_time
+    e.last_updated = datetime.now(timezone.utc)
+    return e
+
+
+class TestUpsertAlgoTimeLeaderboardEntry:
+
+    def _setup_db(self, mock_db, user, uqi_rows, existing_entry):
+        """Wire mock_db for the upsert AlgoTime flow."""
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = user
+
+        q2 = Mock()
+        q2.join.return_value.join.return_value.filter.return_value.all.return_value = uqi_rows
+
+        q3 = Mock()
+        q3.filter.return_value.first.return_value = existing_entry
+
+        mock_db.query.side_effect = [q1, q2, q3]
+
+    def test_creates_new_entry_when_none_exists(self, mock_db, mock_response):
+        user = _make_user()
+        uqi_rows = [make_uqi_row(100, 60), make_uqi_row(200, 120)]
+        self._setup_db(mock_db, user, uqi_rows, None)
+
+        result = upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+        assert result["totalScore"] == 300
+        assert result["problemsSolved"] == 2
+        assert result["totalTime"] == 180
+
+    def test_updates_existing_entry(self, mock_db, mock_response):
+        user = _make_user()
+        uqi_rows = [make_uqi_row(100, 30)]
+        entry = _make_algotime_entry(total_score=50, problems_solved=0, total_time=10)
+        self._setup_db(mock_db, user, uqi_rows, entry)
+
+        upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        assert entry.total_score == 100   # max(100, 50)
+        assert entry.problems_solved == 1
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_called_once()
+
+    def test_score_never_decreases(self, mock_db, mock_response):
+        """If recalculated score < stored score, stored score is kept."""
+        user = _make_user()
+        uqi_rows = [make_uqi_row(None)]   # all null → calculated = 0
+        entry = _make_algotime_entry(total_score=300, problems_solved=3, total_time=0)
+        self._setup_db(mock_db, user, uqi_rows, entry)
+
+        upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        assert entry.total_score == 300   # max(0, 300) preserved
+        assert entry.problems_solved == 3
+
+    def test_user_not_found_raises_404(self, mock_db, mock_response):
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = None
+        mock_db.query.return_value = q1
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_database_error_raises_500(self, mock_db, mock_response):
+        mock_db.query.side_effect = Exception("DB error")
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 500
+
+    def test_response_shape(self, mock_db, mock_response):
+        user = _make_user("Bob", "Jones")
+        uqi_rows = [make_uqi_row(100, 45)]
+        self._setup_db(mock_db, user, uqi_rows, None)
+
+        result = upsert_algotime_leaderboard_entry(_make_algotime_request(user_id=7), mock_response, mock_db)
+
+        assert result["userId"] == 7
+        assert result["name"] == "Bob Jones"
+        assert "totalScore" in result
+        assert "problemsSolved" in result
+        assert "totalTime" in result
+        assert "lastUpdated" in result
+
+    def test_no_cache_headers_set(self, mock_db, mock_response):
+        user = _make_user()
+        self._setup_db(mock_db, user, [], None)
+
+        upsert_algotime_leaderboard_entry(_make_algotime_request(), mock_response, mock_db)
+
+        assert mock_response.headers.get("Cache-Control") == "no-store, no-cache, must-revalidate"
+
+
+# ---------------------------------------------------------------------------
+# upsert_competition_leaderboard_entry
+# ---------------------------------------------------------------------------
+
+def _make_competition_request(user_id=1, competition_id=10):
+    return CompetitionEntryUpsertRequest(user_id=user_id, competition_id=competition_id)
+
+
+def _make_competition_entry(competition_id=10, user_id=1, total_score=100, problems_solved=1, total_time=60):
+    e = Mock()
+    e.competition_leaderboard_entry_id = 55
+    e.competition_id = competition_id
+    e.user_id = user_id
+    e.total_score = total_score
+    e.problems_solved = problems_solved
+    e.total_time = total_time
+    return e
+
+
+class TestUpsertCompetitionLeaderboardEntry:
+
+    def _setup_db(self, mock_db, user, competition, uqi_rows, existing_entry):
+        """Wire mock_db for the upsert competition flow."""
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = user
+
+        q2 = Mock()
+        q2.filter.return_value.first.return_value = competition
+
+        q3 = Mock()
+        q3.join.return_value.filter.return_value.all.return_value = uqi_rows
+
+        q4 = Mock()
+        q4.filter.return_value.first.return_value = existing_entry
+
+        mock_db.query.side_effect = [q1, q2, q3, q4]
+
+    def test_creates_new_entry_when_none_exists(self, mock_db, mock_response):
+        user = _make_user()
+        comp = Mock()
+        uqi_rows = [make_uqi_row(100, 30), make_uqi_row(200, 90)]
+        self._setup_db(mock_db, user, comp, uqi_rows, None)
+
+        result = upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+        assert result["totalScore"] == 300
+        assert result["problemsSolved"] == 2
+        assert result["totalTime"] == 120
+        assert result["competitionId"] == 10
+
+    def test_updates_existing_entry(self, mock_db, mock_response):
+        user = _make_user()
+        comp = Mock()
+        uqi_rows = [make_uqi_row(200, 45)]
+        entry = _make_competition_entry(total_score=100, problems_solved=1, total_time=10)
+        self._setup_db(mock_db, user, comp, uqi_rows, entry)
+
+        upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert entry.total_score == 200   # max(200, 100)
+        assert entry.problems_solved == 1
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_called_once()
+
+    def test_score_never_decreases(self, mock_db, mock_response):
+        user = _make_user()
+        comp = Mock()
+        uqi_rows = [make_uqi_row(None)]   # calculated = 0
+        entry = _make_competition_entry(total_score=500, problems_solved=5, total_time=0)
+        self._setup_db(mock_db, user, comp, uqi_rows, entry)
+
+        upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert entry.total_score == 500   # max(0, 500) preserved
+        assert entry.problems_solved == 5
+
+    def test_user_not_found_raises_404(self, mock_db, mock_response):
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = None
+        mock_db.query.return_value = q1
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_competition_not_found_raises_404(self, mock_db, mock_response):
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = _make_user()
+        q2 = Mock()
+        q2.filter.return_value.first.return_value = None
+        mock_db.query.side_effect = [q1, q2]
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 404
+
+    def test_database_error_raises_500(self, mock_db, mock_response):
+        mock_db.query.side_effect = Exception("DB error")
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 500
+
+    def test_response_shape(self, mock_db, mock_response):
+        user = _make_user("Carol", "White")
+        comp = Mock()
+        uqi_rows = [make_uqi_row(100, 60)]
+        self._setup_db(mock_db, user, comp, uqi_rows, None)
+
+        result = upsert_competition_leaderboard_entry(
+            _make_competition_request(user_id=3, competition_id=10), mock_response, mock_db
+        )
+
+        assert result["userId"] == 3
+        assert result["competitionId"] == 10
+        assert result["name"] == "Carol White"
+        assert "totalScore" in result
+        assert "problemsSolved" in result
+        assert "totalTime" in result
+
+    def test_no_cache_headers_set(self, mock_db, mock_response):
+        user = _make_user()
+        comp = Mock()
+        self._setup_db(mock_db, user, comp, [], None)
+
+        upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert mock_response.headers.get("Cache-Control") == "no-store, no-cache, must-revalidate"
+
+    def test_http_exception_propagated_not_wrapped(self, mock_db, mock_response):
+        q1 = Mock()
+        q1.filter.return_value.first.return_value = _make_user()
+        q2 = Mock()
+        q2.filter.return_value.first.side_effect = HTTPException(status_code=403, detail="Forbidden")
+        mock_db.query.side_effect = [q1, q2]
+
+        with pytest.raises(HTTPException) as exc_info:
+            upsert_competition_leaderboard_entry(_make_competition_request(), mock_response, mock_db)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "Forbidden"

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -374,6 +374,15 @@ export async function getAllAlgoTimeEntriesForExport(): Promise<AlgoTimeEntry[]>
     }
 }
 
+export async function upsertAlgoTimeLeaderboardEntry(userId: number): Promise<void> {
+    try {
+        await axiosClient.put("/leaderboards/algotime/entry", { user_id: userId });
+    } catch (err) {
+        console.error("Error upserting AlgoTime leaderboard entry:", err);
+        throw err;
+    }
+}
+
 export async function resetAlgoTimeLeaderboard(): Promise<{ message: string; entriesDeleted: number }> {
     try {
         const response = await axiosClient.delete<{ message: string; entriesDeleted: number }>(

--- a/frontend/src/api/LeaderboardsAPI.tsx
+++ b/frontend/src/api/LeaderboardsAPI.tsx
@@ -374,6 +374,15 @@ export async function getAllAlgoTimeEntriesForExport(): Promise<AlgoTimeEntry[]>
     }
 }
 
+export async function upsertCompetitionLeaderboardEntry(userId: number, competitionId: number): Promise<void> {
+    try {
+        await axiosClient.put("/leaderboards/competitions/entry", { user_id: userId, competition_id: competitionId });
+    } catch (err) {
+        console.error("Error upserting competition leaderboard entry:", err);
+        throw err;
+    }
+}
+
 export async function upsertAlgoTimeLeaderboardEntry(userId: number): Promise<void> {
     try {
         await axiosClient.put("/leaderboards/algotime/entry", { user_id: userId });

--- a/frontend/src/api/SubmitCodeAPI.tsx
+++ b/frontend/src/api/SubmitCodeAPI.tsx
@@ -9,6 +9,7 @@ import { logFrontend } from "./LoggerAPI"
 import { updateMostRecentSub } from "./MostRecentSubAPI"
 import { saveSubmission } from "./SubmissionAPI"
 import { putUserInstance } from "./UserQuestionInstanceAPI"
+import { upsertAlgoTimeLeaderboardEntry } from "./LeaderboardsAPI"
 
 export async function submitAttempt(
     question: Question | undefined,
@@ -19,6 +20,7 @@ export async function submitAttempt(
     language_id: number | undefined,
     testcases: TestCase[],
     userId: number,
+    isAlgoTime: boolean = false,
   ): Promise<SubmitAttemptResponse> {
     try {
       if (!questionInstance || !userQuestionInstance || !question || !language_id) {
@@ -49,7 +51,10 @@ export async function submitAttempt(
       // 4. Save most recent submission
       const mostRecentSubResponse = await updateMostRecentSub(userQuestionInstance.user_question_instance_id, source_code, language_id)
 
-      // 5. Updates leaderboard (Leave this here for now)
+      // 5. Update AlgoTime leaderboard if this is an AlgoTime session
+      if (isAlgoTime && event) {
+        await upsertAlgoTimeLeaderboardEntry(userId)
+      }
 
       // 6. Save submission's output details
       let runtime: number | null = null

--- a/frontend/src/api/SubmitCodeAPI.tsx
+++ b/frontend/src/api/SubmitCodeAPI.tsx
@@ -9,7 +9,7 @@ import { logFrontend } from "./LoggerAPI"
 import { updateMostRecentSub } from "./MostRecentSubAPI"
 import { saveSubmission } from "./SubmissionAPI"
 import { putUserInstance } from "./UserQuestionInstanceAPI"
-import { upsertAlgoTimeLeaderboardEntry } from "./LeaderboardsAPI"
+import { upsertAlgoTimeLeaderboardEntry, upsertCompetitionLeaderboardEntry } from "./LeaderboardsAPI"
 
 export async function submitAttempt(
     question: Question | undefined,
@@ -51,9 +51,11 @@ export async function submitAttempt(
       // 4. Save most recent submission
       const mostRecentSubResponse = await updateMostRecentSub(userQuestionInstance.user_question_instance_id, source_code, language_id)
 
-      // 5. Update AlgoTime leaderboard if this is an AlgoTime session
+      // 5. Update leaderboard based on session type
       if (isAlgoTime && event) {
         await upsertAlgoTimeLeaderboardEntry(userId)
+      } else if (!isAlgoTime && event) {
+        await upsertCompetitionLeaderboardEntry(userId, event.event_id)
       }
 
       // 6. Save submission's output details

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -128,7 +128,7 @@ const CodingView = () => {
       } = await submitAttempt(
         activeQuestion, activeQuestionInstance,
         userQuestionInstance, event,
-        code, selectedLang?.lang_judge_id, testcases, user?.id ?? 0)
+        code, selectedLang?.lang_judge_id, testcases, user?.id ?? 0, !!algo)
 
       setLatestSubmissionResult(submissionResponse)
 

--- a/frontend/tests/CodingView.test.tsx
+++ b/frontend/tests/CodingView.test.tsx
@@ -577,9 +577,10 @@ describe('CodingView - submit code', () => {
         await userEvent.click(screen.getByTestId('submit-btn'))
         await waitFor(() => expect(submitAttempt).toHaveBeenCalledTimes(1))
         // expect.anything() does NOT match null, and the default hook mock has
-        // userQuestionInstance=null and event=null. Check just the last arg (userId).
+        // userQuestionInstance=null and event=null. Check userId and isAlgoTime args.
         const callArgs = mockedSubmitAttempt.mock.calls[0]
-        expect(callArgs[callArgs.length - 1]).toBe(user_id)
+        expect(callArgs[callArgs.length - 2]).toBe(user_id)   // userId
+        expect(callArgs[callArgs.length - 1]).toBe(false)      // isAlgoTime (no algo session)
     })
 
     it('shows submission result inline (not toast) when Accepted', async () => {


### PR DESCRIPTION
## 📝 Description

> This PR automatically updates leaderboard scores on every code submission for both AlgoTime and Competition 
  sessions. Scoring is all-or-nothing,  depending on question's difficulty, user  can get points  only on an Accepted verdict, with no partial credit. Users can safely leave and rejoin a session without  losing their accumulated score. 

## 🔧 Changes Made

  - Added upsert endpoints for AlgoTime and Competition leaderboards, called automatically on every submission
  - Fixed score resetting to 0 when a user leaves and rejoins a session
  - Added 22 new tests for the new endpoints

## 🎯 Related Issues

Closes #383 

## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ]  I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)
AlgoTime & Competitions examples for testing purposes  (solved 2 hard questions & 1 easy question: 2 * 300 + 1 * 100 = 700)
<img width="1279" height="768" alt="Screenshot 2026-03-26 at 12 39 04 AM" src="https://github.com/user-attachments/assets/032a8b13-6d5c-478d-9d02-eb9bf55673cd" />
<img width="1233" height="748" alt="Screenshot 2026-03-26 at 12 03 16 AM" src="https://github.com/user-attachments/assets/891a6957-2723-4c6b-a101-f9b7c291957f" />


## 💬 Additional Notes

Next step: we might need to test with more than one user during a competition submitting at the same time
