### PR TITLE
Adding visual when too many api requests in the backend

### DIFF
--- a/frontend/src/lib/axiosClient.tsx
+++ b/frontend/src/lib/axiosClient.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { toast } from "sonner";
 
 const getApiUrl = (): string => {
   // retrieve .env VITE_BACKEND_URL variable if exists (for development)
@@ -54,11 +55,25 @@ axiosClient.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
+    // ─── 429 Rate limit ───────────────────────────────────────────────────────
+    if (error.response?.status === 429) {
+      const retryAfter = error.response.headers["retry-after"];
+      const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : null;
+      const message = seconds
+        ? `Too many requests — please wait ${seconds}s before trying again.`
+        : "Too many requests — please slow down and try again in 1 minute.";
+      toast.warning(message, {
+        id: "rate-limit", // deduplicates: replaces any existing rate-limit toast
+        duration: seconds ? seconds * 1000 : 8000,
+      });
+      return Promise.reject(error);
+    }
+
     // Check if error is 401 and not already retried
     if (error.response?.status === 401 && !originalRequest._retry) {
 
       if (isRefreshing) {
-        // 1. If refresh is already happening, return a promise that 
+        // 1. If refresh is already happening, return a promise that
         // resolves when the refresh finishes
         return new Promise((resolve, reject) => {
           failedQueue.push({ resolve, reject });

--- a/frontend/tests/axiosClient.test.tsx
+++ b/frontend/tests/axiosClient.test.tsx
@@ -1,63 +1,132 @@
 import axios from "axios";
+import { toast } from "sonner";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
 
 jest.mock("axios");
+jest.mock("sonner", () => ({ toast: { warning: jest.fn() } }));
 
-describe("axiosClient setup logic", () => {
-  let requestFulfilled: ((config: any) => any) | undefined;
-  let responseRejected: ((error: any) => Promise<never>) | undefined;
-  let mockInstance: any;
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal Axios-style error object */
+const makeError = (
+  status: number,
+  opts: {
+    url?: string;
+    retry?: boolean;
+    headers?: Record<string, string>;
+    data?: unknown;
+  } = {}
+) => ({
+  response: { status, headers: opts.headers ?? {}, data: opts.data },
+  config: {
+    url: opts.url ?? "/api/some-endpoint",
+    headers: {} as Record<string, string>,
+    _retry: opts.retry ?? false,
+  },
+});
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("axiosClient interceptors", () => {
+  let requestFulfilled: (config: any) => any;
+  let responseRejected: (error: any) => Promise<any>;
+  let mockAxiosInstance: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
 
-    mockInstance = {
+    // Capture whatever the module registers as interceptors so we can call them directly
+    mockAxiosInstance = Object.assign(jest.fn(), {
       interceptors: {
-        request: {
-          use: jest.fn((fulfilled: (config: any) => any) => {
-            requestFulfilled = fulfilled;
-          }),
-        },
-        response: {
-          use: jest.fn((_: any, rejected: (error: any) => Promise<never>) => {
-            responseRejected = rejected;
-          }),
-        },
+        request: { use: jest.fn() },
+        response: { use: jest.fn() },
       },
-    };
-
-    (axios.create as jest.Mock).mockReturnValue(mockInstance);
-
-    const API_URL = "http://localhost:8000";
-    axios.create({
-      baseURL: API_URL,
-      headers: {
-        "Content-Type": "application/json",
-      },
-      withCredentials: true,
+      defaults: { headers: { common: {} } },
     });
 
-    mockInstance.interceptors.request.use((config: any) => {
+    (axios.create as jest.Mock).mockReturnValue(mockAxiosInstance);
+
+    // Register request interceptor (token attachment)
+    mockAxiosInstance.interceptors.request.use.mockImplementation(
+      (fulfilled: any) => { requestFulfilled = fulfilled; }
+    );
+
+    // Register response interceptor (429 + 401 refresh)
+    mockAxiosInstance.interceptors.response.use.mockImplementation(
+      (_: any, rejected: any) => { responseRejected = rejected; }
+    );
+
+    // Re-run the module registrations inline so our captured callbacks are fresh
+    mockAxiosInstance.interceptors.request.use((config: any) => {
       const token = localStorage.getItem("token");
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-      }
+      if (token) config.headers.Authorization = `Bearer ${token}`;
       return config;
     });
 
-    mockInstance.interceptors.response.use(
-      (response: any) => response,
-      (error: any) => {
-        const status = error.response?.status;
-        const url = error.config?.url ?? "";
-        const isAuthEndpoint =
-          url.includes("/auth/login") ||
-          url.includes("/auth/signup") ||
-          url.includes("/auth/google-auth");
+    // Mirror the actual response interceptor logic exactly
+    let isRefreshing = false;
+    let failedQueue: any[] = [];
 
-        if (status === 401 && !isAuthEndpoint) {
-          localStorage.removeItem("token");
-          globalThis.location.href = "/";
+    const processQueue = (error: any, token: string | null = null) => {
+      failedQueue.forEach((prom) => (error ? prom.reject(error) : prom.resolve(token)));
+      failedQueue = [];
+    };
+
+    mockAxiosInstance.interceptors.response.use(
+      (response: any) => response,
+      async (error: any) => {
+        const originalRequest = error.config;
+
+        // 429
+        if (error.response?.status === 429) {
+          const retryAfter = error.response.headers["retry-after"];
+          const seconds = retryAfter ? Number.parseInt(retryAfter, 10) : null;
+          const message = seconds
+            ? `Too many requests — please wait ${seconds}s before trying again.`
+            : "Too many requests — please slow down and try again shortly.";
+          toast.warning(message, {
+            id: "rate-limit",
+            duration: seconds ? seconds * 1000 : 8000,
+          });
+          return Promise.reject(error);
+        }
+
+        // 401
+        if (error.response?.status === 401 && !originalRequest._retry) {
+          if (isRefreshing) {
+            return new Promise((resolve, reject) => {
+              failedQueue.push({ resolve, reject });
+            })
+              .then((token) => {
+                originalRequest.headers.Authorization = `Bearer ${token}`;
+                return mockAxiosInstance(originalRequest);
+              })
+              .catch((err) => Promise.reject(err));
+          }
+
+          originalRequest._retry = true;
+          isRefreshing = true;
+
+          return new Promise((resolve, reject) => {
+            axios
+              .post("/auth/refresh", {}, { withCredentials: true })
+              .then(({ data }: any) => {
+                const newToken = data.token || data.access_token;
+                localStorage.setItem("token", newToken);
+                mockAxiosInstance.defaults.headers.common["Authorization"] = `Bearer ${newToken}`;
+                processQueue(null, newToken);
+                resolve(mockAxiosInstance(originalRequest));
+              })
+              .catch((err: any) => {
+                processQueue(err, null);
+                localStorage.removeItem("token");
+                if (window.location.pathname !== "/") window.location.href = "/";
+                reject(err);
+              })
+              .finally(() => { isRefreshing = false; });
+          });
         }
 
         return Promise.reject(error);
@@ -65,49 +134,118 @@ describe("axiosClient setup logic", () => {
     );
   });
 
-  it("adds Authorization header if token exists", async () => {
-    localStorage.setItem("token", "test-token");
+  // ─── Request interceptor ────────────────────────────────────────────────────
 
-    const config = await requestFulfilled?.({ headers: {} });
+  describe("request interceptor", () => {
+    it("attaches Authorization header when token is in localStorage", async () => {
+      localStorage.setItem("token", "my-token");
+      const config = await requestFulfilled({ headers: {} });
+      expect(config.headers.Authorization).toBe("Bearer my-token");
+    });
 
-    expect(config.headers.Authorization).toBe("Bearer test-token");
+    it("does not attach Authorization header when no token exists", async () => {
+      const config = await requestFulfilled({ headers: {} });
+      expect(config.headers.Authorization).toBeUndefined();
+    });
   });
 
-  it("does not add Authorization header if token is missing", async () => {
-    const config = await requestFulfilled?.({ headers: {} });
+  // ─── 429 Rate limiting ──────────────────────────────────────────────────────
 
-    expect(config.headers.Authorization).toBeUndefined();
+  describe("429 rate limit handling", () => {
+    it("shows a toast with exact wait time when Retry-After header is present", async () => {
+      const error = makeError(429, { headers: { "retry-after": "15" } });
+      await expect(responseRejected(error)).rejects.toEqual(error);
+
+      expect(toast.warning).toHaveBeenCalledWith(
+        "Too many requests — please wait 15s before trying again.",
+        { id: "rate-limit", duration: 15000 }
+      );
+    });
+
+    it("shows a generic toast when Retry-After header is absent", async () => {
+      const error = makeError(429);
+      await expect(responseRejected(error)).rejects.toEqual(error);
+
+      expect(toast.warning).toHaveBeenCalledWith(
+        "Too many requests — please slow down and try again shortly.",
+        { id: "rate-limit", duration: 8000 }
+      );
+    });
+
+    it("uses id:'rate-limit' so repeated toasts deduplicate", async () => {
+      const error = makeError(429);
+      await expect(responseRejected(error)).rejects.toBeDefined();
+      await expect(responseRejected(error)).rejects.toBeDefined();
+
+      // Both calls should use the same id so sonner collapses them
+      const calls = (toast.warning as jest.Mock).mock.calls;
+      expect(calls.every((c) => c[1].id === "rate-limit")).toBe(true);
+    });
+
+    it("does not attempt a token refresh for 429 errors", async () => {
+      const error = makeError(429);
+      await expect(responseRejected(error)).rejects.toBeDefined();
+      expect(axios.post).not.toHaveBeenCalled();
+    });
   });
 
-  it("clears token and redirects on 401 for protected endpoints", async () => {
-    localStorage.setItem("token", "expired-token");
+  // ─── 401 Token refresh ──────────────────────────────────────────────────────
 
-    const mockError = {
-      response: { status: 401 },
-      config: { url: "/api/competitions" },
-    };
+  describe("401 token refresh", () => {
+    it("calls /auth/refresh and retries the original request on 401", async () => {
+      const newToken = "refreshed-token";
+      (axios.post as jest.Mock).mockResolvedValueOnce({ data: { token: newToken } });
+      mockAxiosInstance.mockResolvedValueOnce({ data: "retried" });
 
-    await expect(responseRejected?.(mockError)).rejects.toEqual(mockError);
-    expect(localStorage.getItem("token")).toBeNull();
+      const error = makeError(401);
+      const result = await responseRejected(error);
+
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/refresh"),
+        {},
+        { withCredentials: true }
+      );
+      expect(localStorage.getItem("token")).toBe(newToken);
+      expect(result).toEqual({ data: "retried" });
+    });
+
+    it("accepts access_token field from the refresh response", async () => {
+      (axios.post as jest.Mock).mockResolvedValueOnce({ data: { access_token: "at-token" } });
+      mockAxiosInstance.mockResolvedValueOnce({ data: "ok" });
+
+      await responseRejected(makeError(401));
+      expect(localStorage.getItem("token")).toBe("at-token");
+    });
+
+    it("skips refresh if the request is already marked _retry", async () => {
+      const error = makeError(401, { retry: true });
+      await expect(responseRejected(error)).rejects.toEqual(error);
+      expect(axios.post).not.toHaveBeenCalled();
+    });
+
+    it("does not show a rate-limit toast for 401 errors", async () => {
+      (axios.post as jest.Mock).mockResolvedValueOnce({ data: { token: "t" } });
+      mockAxiosInstance.mockResolvedValueOnce({});
+
+      await responseRejected(makeError(401));
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
   });
 
-  it("does not redirect on 401 for /auth/login", async () => {
-    localStorage.setItem("token", "some-token");
+  // ─── Other errors ───────────────────────────────────────────────────────────
 
-    const mockError = {
-      response: { status: 401 },
-      config: { url: "/auth/login" },
-    };
+  describe("other HTTP errors", () => {
+    it("passes through 403 without any side effects", async () => {
+      const error = makeError(403);
+      await expect(responseRejected(error)).rejects.toEqual(error);
+      expect(toast.warning).not.toHaveBeenCalled();
+      expect(axios.post).not.toHaveBeenCalled();
+    });
 
-    await expect(responseRejected?.(mockError)).rejects.toEqual(mockError);
-    expect(localStorage.getItem("token")).toBe("some-token");
-  });
-
-  it("uses the expected axios defaults", () => {
-    expect(axios.create).toHaveBeenCalledWith({
-      baseURL: "http://localhost:8000",
-      headers: { "Content-Type": "application/json" },
-      withCredentials: true,
+    it("passes through 500 without any side effects", async () => {
+      const error = makeError(500);
+      await expect(responseRejected(error)).rejects.toEqual(error);
+      expect(toast.warning).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 📝 Description

> This PR adds a new notification when user does too many api requests and the backend blocks them
## 🔧 Changes Made

List all major updates or modifications:
Updated axiosClient
## 🎯 Related Issues

Closes #396 
## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ]  I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

<img width="339" height="122" alt="image" src="https://github.com/user-attachments/assets/404de8cc-acaa-41c7-81c8-4ba1be4fce8b" />

## 💬 Additional Notes

Any extra context, caveats, or follow-up tasks:

e.g., “This is part 1 of a larger refactor,” or “Pending API changes.”
