### PR TITLE
Bug/415-Input-Time-On-Safari

### DIFF
--- a/frontend/src/helpers/TimeInput.tsx
+++ b/frontend/src/helpers/TimeInput.tsx
@@ -139,7 +139,7 @@ export const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(
                   key={t.value24}
                   data-selected={value === t.value24}
                   onClick={() => handleSelect(t.value24)}
-                  className={`cursor-pointer px-3 py-2 text-sm transition-colors ${
+                  className={`cursor-pointer w-full block  px-3 py-2 text-sm transition-colors ${
                     value === t.value24
                       ? "bg-primary/15 font-semibold text-primary"
                       : "hover:bg-primary/5"


### PR DESCRIPTION
## 📝 Description

> This PR changes the time input layout because it was inconsistent with safari browser. 

## 🔧 Changes Made

List all major updates or modifications:

Fixed Time Input Layout in TimeInput.tsx

## 🎯 Related Issues

Closes #415 


## ✅ Checklist

Before requesting review, confirm the following:

 - [x] My code follows the project’s style guidelines
 - [x] I’ve performed a self-review of my own code
 - [x] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [x]  I’ve added or updated tests if applicable
 - [x] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)
Old layout 
<img width="426" height="642" alt="image" src="https://github.com/user-attachments/assets/b55a711d-f32b-404b-9da8-dff563875892" />
New Layout 
<img width="202" height="259" alt="Screenshot 2026-03-29 at 6 06 45 PM" src="https://github.com/user-attachments/assets/81bcc060-8337-4226-a01b-218ea4c5b2cc" />

Add screenshots or GIFs if your changes affect the UI.

## 💬 Additional Notes

Any extra context, caveats, or follow-up tasks:

e.g., “This is part 1 of a larger refactor,” or “Pending API changes.”
