### PR TITLE
Fix skeleton loading states and redirect to home on competition timeout 

### DIFF
--- a/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
+++ b/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
@@ -29,9 +29,7 @@ export default function AlgoTimePageSkeleton() {
             </div>
 
             <div className="flex items-center justify-end pt-2 border-t pb-4">
-              <Button disabled size="sm" className="w-28">
-                <Skeleton className="h-3 w-16" />
-              </Button>
+              <Skeleton className="h-7 w-24" />
             </div>
           </div>
         </div>

--- a/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
+++ b/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 
 const SKELETON_CARD_COUNT = 8;
 
@@ -28,7 +29,9 @@ export default function AlgoTimePageSkeleton() {
             </div>
 
             <div className="flex items-center justify-end pt-2 border-t pb-4">
-              <Skeleton className="h-7 w-28 rounded-md" />
+              <Button disabled size="sm" className="w-28">
+                <Skeleton className="h-3 w-16" />
+              </Button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
+++ b/frontend/src/components/algotime/AlgoTimePageSkeleton.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 
 const SKELETON_CARD_COUNT = 8;
 

--- a/frontend/src/components/algotime/ManageAlgotimeSessionsSkeleton.tsx
+++ b/frontend/src/components/algotime/ManageAlgotimeSessionsSkeleton.tsx
@@ -1,4 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Eye, Trash2 } from "lucide-react";
 
 export default function ManageAlgotimeSessionsSkeleton() {
   return (
@@ -10,8 +12,13 @@ export default function ManageAlgotimeSessionsSkeleton() {
             <div className="p-4 space-y-3">
               <Skeleton className="h-6 w-3/4" />
               <Skeleton className="h-4 w-1/2" />
-              <div className="pt-2 border-t flex justify-end">
-                <Skeleton className="h-8 w-24" />
+              <div className="pt-2 border-t flex justify-end gap-2">
+                <Button disabled variant="outline" size="sm">
+                  View <Eye className="h-4 w-4" />
+                </Button>
+                <Button disabled variant="outline" size="sm" className="text-destructive">
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/components/codingPage/CompetitionTimer.tsx
+++ b/frontend/src/components/codingPage/CompetitionTimer.tsx
@@ -1,0 +1,40 @@
+interface CompetitionTimerProps {
+  remainingMs: number | null;
+}
+
+export function CompetitionTimer({ remainingMs }: CompetitionTimerProps) {
+  if (remainingMs === null) return null
+
+  const isExpired = remainingMs === 0
+  const isWarning = remainingMs < 5 * 60 * 1000
+  const isUrgent = remainingMs < 60 * 1000
+
+  const totalSeconds = Math.floor(remainingMs / 1000)
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  const display = h > 0
+    ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+    : `${m}:${String(s).padStart(2, '0')}`
+
+  return (
+    <div className={`
+      flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-mono font-medium tabular-nums
+      transition-colors duration-500
+      ${isUrgent && !isExpired ? 'animate-pulse' : ''}
+      ${isExpired || isUrgent
+        ? 'bg-destructive/10 border-destructive/30 text-destructive'
+        : isWarning
+          ? 'bg-amber-500/10 border-amber-500/30 text-amber-600 dark:text-amber-400'
+          : 'bg-muted border-border text-muted-foreground'
+      }
+    `}>
+      <span className={`w-1.5 h-1.5 rounded-full ${isExpired ? 'bg-destructive' :
+        isUrgent ? 'bg-destructive animate-pulse' :
+          isWarning ? 'bg-amber-500 animate-pulse' :
+            'bg-emerald-500'
+        }`} />
+      {isExpired ? "Time's up" : display}
+    </div>
+  )
+}

--- a/frontend/src/components/codingPage/SubmissionSkeleton.tsx
+++ b/frontend/src/components/codingPage/SubmissionSkeleton.tsx
@@ -7,25 +7,27 @@ export const SubmissionSkeleton = () => (
         {/* Header row – status badge + title */}
         <div className="flex items-center gap-4 pb-4 border-b">
             <Skeleton className="h-8 w-24 rounded-full" />
-            <Skeleton className="h-7 w-48 rounded-md" />
+            <h2 className="text-xl font-semibold">Submission Result</h2>
         </div>
 
         {/* Stats grid */}
         <div className="grid grid-cols-2 gap-6">
             {/* Left column */}
             <div className="space-y-4">
-                <Skeleton className="h-4 w-32 rounded" />
+                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+                    Basic Information
+                </h3>
                 <div className="bg-muted/30 rounded-lg p-4 space-y-3">
                     <div className="flex justify-between items-center">
-                        <Skeleton className="h-4 w-16 rounded" />
+                        <span className="text-muted-foreground">Runtime</span>
                         <Skeleton className="h-4 w-20 rounded" />
                     </div>
                     <div className="flex justify-between items-center">
-                        <Skeleton className="h-4 w-16 rounded" />
+                        <span className="text-muted-foreground">Memory</span>
                         <Skeleton className="h-4 w-20 rounded" />
                     </div>
                     <div className="flex justify-between items-center">
-                        <Skeleton className="h-4 w-20 rounded" />
+                        <span className="text-muted-foreground">Submitted</span>
                         <Skeleton className="h-4 w-28 rounded" />
                     </div>
                 </div>
@@ -33,7 +35,9 @@ export const SubmissionSkeleton = () => (
 
             {/* Right column */}
             <div className="space-y-4">
-                <Skeleton className="h-4 w-40 rounded" />
+                <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+                    Additional Information
+                </h3>
                 <div className="bg-muted/30 rounded-lg p-4 space-y-3">
                     <Skeleton className="h-4 w-full rounded" />
                     <Skeleton className="h-4 w-3/4 rounded" />
@@ -44,14 +48,16 @@ export const SubmissionSkeleton = () => (
 
         {/* Output section */}
         <div className="space-y-4">
-            <Skeleton className="h-4 w-32 rounded" />
+            <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">
+                Program Output
+            </h3>
             <div className="grid grid-cols-2 gap-4">
                 <div className="bg-muted/30 rounded-lg p-4 space-y-2">
-                    <Skeleton className="h-3 w-28 rounded" />
+                    <span className="text-muted-foreground block text-sm">Standard Output</span>
                     <Skeleton className="h-24 w-full rounded" />
                 </div>
                 <div className="bg-muted/30 rounded-lg p-4 space-y-2">
-                    <Skeleton className="h-3 w-28 rounded" />
+                    <span className="text-muted-foreground block text-sm">Standard Error</span>
                     <Skeleton className="h-24 w-full rounded" />
                 </div>
             </div>

--- a/frontend/src/components/codingPage/TimesUpDialog.tsx
+++ b/frontend/src/components/codingPage/TimesUpDialog.tsx
@@ -1,0 +1,28 @@
+import { Timer } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+
+interface TimesUpDialogProps {
+  redirectCountdown: number | null;
+}
+
+export function TimesUpDialog({ redirectCountdown }: TimesUpDialogProps) {
+  return (
+    <Dialog open={redirectCountdown !== null}>
+      <DialogContent className="sm:max-w-sm text-center" onInteractOutside={(e) => e.preventDefault()}>
+        <div className="flex flex-col items-center gap-4 py-4">
+          <div className="flex items-center justify-center w-16 h-16 rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <Timer className="w-8 h-8 text-amber-600 dark:text-amber-400" />
+          </div>
+          <DialogTitle className="text-xl font-semibold">Time's Up!</DialogTitle>
+          <p className="text-muted-foreground text-sm">
+            The competition has ended. Thanks for participating!
+          </p>
+          <p className="text-sm">
+            Redirecting you to the home page in{' '}
+            <span className="font-bold text-primary">{redirectCountdown}s</span>
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/competitions/CompetitionsPageSkeleton.tsx
+++ b/frontend/src/components/competitions/CompetitionsPageSkeleton.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 
 const SKELETON_CARD_COUNT = 8;
 
@@ -28,9 +27,7 @@ export default function CompetitionsPageSkeleton() {
             </div>
 
             <div className="flex items-center justify-end pt-2 border-t pb-4">
-              <Button disabled size="sm" className="w-28">
-                <Skeleton className="h-3 w-16" />
-              </Button>
+              <Skeleton className="h-7 w-24" />
             </div>
           </div>
         </div>

--- a/frontend/src/components/competitions/CompetitionsPageSkeleton.tsx
+++ b/frontend/src/components/competitions/CompetitionsPageSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 
 const SKELETON_CARD_COUNT = 8;
 
@@ -27,7 +28,9 @@ export default function CompetitionsPageSkeleton() {
             </div>
 
             <div className="flex items-center justify-end pt-2 border-t pb-4">
-              <Skeleton className="h-7 w-28 rounded-md" />
+              <Button disabled size="sm" className="w-28">
+                <Skeleton className="h-3 w-16" />
+              </Button>
             </div>
           </div>
         </div>

--- a/frontend/src/components/helpers/TableSkeletonPagination.tsx
+++ b/frontend/src/components/helpers/TableSkeletonPagination.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export function TableSkeletonPagination() {
+  return (
+    <div className="flex flex-row items-center justify-between gap-3 py-4">
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-9 w-20" />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+          <ChevronLeft className="h-4 w-4" /> Previous
+        </Button>
+        <Skeleton className="h-9 w-9" />
+        <Skeleton className="h-9 w-9" />
+        <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+          Next <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/leaderboards/CodingPageLeaderboard.tsx
+++ b/frontend/src/components/leaderboards/CodingPageLeaderboard.tsx
@@ -62,13 +62,13 @@ export function EventLeaderboard({ eventId, eventName, isCompetitionEvent, curre
       <div className="flex flex-col gap-3">
         {/* Header */}
         <div className="flex items-center justify-between mb-1">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="h-3 w-32" />
+          <h2 className="text-base font-semibold text-primary">{eventName}</h2>
+          <span className="text-xs text-muted-foreground">Refreshes every minute</span>
         </div>
         {/* Table header */}
         <div className="flex items-center gap-4 border-b pb-2">
-          {[24, 140, 80, 60].map((w, i) => (
-            <Skeleton key={i} className="h-3 rounded" style={{ width: w }} />
+          {["Rank", "Name", "Total Points", "Problems Solved", "Total Time"].map((label, i) => (
+            <span key={i} className="text-xs text-muted-foreground font-medium">{label}</span>
           ))}
         </div>
         {/* Rows */}

--- a/frontend/src/components/manageAccounts/ManageAccountsSkeleton.tsx
+++ b/frontend/src/components/manageAccounts/ManageAccountsSkeleton.tsx
@@ -1,4 +1,7 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export default function ManageAccountsTableSkeleton() {
   const bodyRows = 8;
@@ -6,16 +9,20 @@ export default function ManageAccountsTableSkeleton() {
   return (
     <div aria-busy="true" aria-live="polite">
       <div className="overflow-hidden rounded-md border">
+        {/* Column headers */}
         <div className="border-b px-4 py-3">
-          <div className="grid grid-cols-12 gap-4">
-            <Skeleton className="h-4 col-span-1" />
-            <Skeleton className="h-4 col-span-3" />
-            <Skeleton className="h-4 col-span-4" />
-            <Skeleton className="h-4 col-span-2" />
-            <Skeleton className="h-4 col-span-2" />
+          <div className="grid grid-cols-12 gap-4 items-center">
+            <div className="col-span-1 flex justify-center">
+              <Checkbox disabled />
+            </div>
+            <span className="col-span-3 text-sm font-medium">Name</span>
+            <span className="col-span-4 text-sm font-medium">Email</span>
+            <span className="col-span-2 text-sm font-medium text-right">Account Type</span>
+            <span className="col-span-2 text-sm font-medium">Actions</span>
           </div>
         </div>
 
+        {/* Data rows */}
         <div className="p-4 space-y-4">
           {Array.from({ length: bodyRows }, (_, index) => (
             <div key={index} className="grid grid-cols-12 gap-4 items-center">
@@ -29,16 +36,21 @@ export default function ManageAccountsTableSkeleton() {
         </div>
       </div>
 
+      {/* Pagination footer */}
       <div className="flex flex-row items-center justify-between gap-3 py-4">
         <div className="flex items-center gap-4">
           <Skeleton className="h-5 w-24" />
           <Skeleton className="h-9 w-20" />
         </div>
         <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-24" />
+          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+            <ChevronLeft className="h-4 w-4" /> Previous
+          </Button>
           <Skeleton className="h-9 w-9" />
           <Skeleton className="h-9 w-9" />
-          <Skeleton className="h-9 w-24" />
+          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/manageAccounts/ManageAccountsSkeleton.tsx
+++ b/frontend/src/components/manageAccounts/ManageAccountsSkeleton.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { TableSkeletonPagination } from "@/components/helpers/TableSkeletonPagination";
 
 export default function ManageAccountsTableSkeleton() {
   const bodyRows = 8;
@@ -36,23 +35,7 @@ export default function ManageAccountsTableSkeleton() {
         </div>
       </div>
 
-      {/* Pagination footer */}
-      <div className="flex flex-row items-center justify-between gap-3 py-4">
-        <div className="flex items-center gap-4">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-9 w-20" />
-        </div>
-        <div className="flex items-center gap-2">
-          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
-            <ChevronLeft className="h-4 w-4" /> Previous
-          </Button>
-          <Skeleton className="h-9 w-9" />
-          <Skeleton className="h-9 w-9" />
-          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
-            Next <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
+      <TableSkeletonPagination />
     </div>
   );
 }

--- a/frontend/src/components/manageCompetitions/ManageCompetitionsSkeleton.tsx
+++ b/frontend/src/components/manageCompetitions/ManageCompetitionsSkeleton.tsx
@@ -1,6 +1,12 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
 
-export default function ManageCompetitionsSkeleton() {
+type ManageCompetitionsSkeletonProps = {
+  readonly isOwner?: boolean;
+};
+
+export default function ManageCompetitionsSkeleton({ isOwner = false }: ManageCompetitionsSkeletonProps) {
   return (
     <div aria-busy="true" aria-live="polite">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
@@ -11,9 +17,13 @@ export default function ManageCompetitionsSkeleton() {
               <Skeleton className="h-6 w-3/4" />
               <Skeleton className="h-4 w-1/2" />
               <Skeleton className="h-4 w-1/3" />
-              <div className="pt-2 border-t">
-                <Skeleton className="h-8 w-24 ml-auto" />
-              </div>
+              {isOwner && (
+                <div className="pt-2 border-t flex justify-end">
+                  <Button disabled variant="ghost" size="sm" className="h-8 text-destructive">
+                    Delete <Trash2 className="h-4 w-4 ml-1" />
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/components/manageQuestions/ManageQuestionsSkeleton.tsx
+++ b/frontend/src/components/manageQuestions/ManageQuestionsSkeleton.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { TableSkeletonPagination } from "@/components/helpers/TableSkeletonPagination";
 
 export default function ManageQuestionsTableSkeleton() {
   const bodyRows = 8;
@@ -40,23 +39,7 @@ export default function ManageQuestionsTableSkeleton() {
         </div>
       </div>
 
-      {/* Pagination footer */}
-      <div className="flex flex-row items-center justify-between gap-3 py-4">
-        <div className="flex items-center gap-4">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-9 w-20" />
-        </div>
-        <div className="flex items-center gap-2">
-          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
-            <ChevronLeft className="h-4 w-4" /> Previous
-          </Button>
-          <Skeleton className="h-9 w-9" />
-          <Skeleton className="h-9 w-9" />
-          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
-            Next <ChevronRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
+      <TableSkeletonPagination />
     </div>
   );
 }

--- a/frontend/src/components/manageQuestions/ManageQuestionsSkeleton.tsx
+++ b/frontend/src/components/manageQuestions/ManageQuestionsSkeleton.tsx
@@ -1,4 +1,7 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export default function ManageQuestionsTableSkeleton() {
   const bodyRows = 8;
@@ -6,18 +9,22 @@ export default function ManageQuestionsTableSkeleton() {
   return (
     <div aria-busy="true" aria-live="polite">
       <div className="overflow-hidden rounded-md border">
+        {/* Column headers */}
         <div className="border-b px-4 py-3">
-          <div className="grid grid-cols-12 gap-4">
-            <Skeleton className="h-4 col-span-1" />
-            <Skeleton className="h-4 col-span-1" />
-            <Skeleton className="h-4 col-span-2" />
-            <Skeleton className="h-4 col-span-4" />
-            <Skeleton className="h-4 col-span-2" />
-            <Skeleton className="h-4 col-span-1" />
-            <Skeleton className="h-4 col-span-1" />
+          <div className="grid grid-cols-12 gap-4 items-center">
+            <div className="col-span-1 flex justify-center">
+              <Checkbox disabled />
+            </div>
+            <span className="col-span-1 text-sm font-medium text-center">ID</span>
+            <span className="col-span-2 text-sm font-medium text-center">Title</span>
+            <span className="col-span-4 text-sm font-medium text-left">Description</span>
+            <span className="col-span-2 text-sm font-medium text-center">Difficulty</span>
+            <span className="col-span-1 text-sm font-medium text-center">Public</span>
+            <span className="col-span-1 text-sm font-medium text-center">Actions</span>
           </div>
         </div>
 
+        {/* Data rows */}
         <div className="p-4 space-y-4">
           {Array.from({ length: bodyRows }, (_, index) => (
             <div key={index} className="grid grid-cols-12 items-center gap-4">
@@ -33,16 +40,21 @@ export default function ManageQuestionsTableSkeleton() {
         </div>
       </div>
 
+      {/* Pagination footer */}
       <div className="flex flex-row items-center justify-between gap-3 py-4">
         <div className="flex items-center gap-4">
           <Skeleton className="h-5 w-24" />
           <Skeleton className="h-9 w-20" />
         </div>
         <div className="flex items-center gap-2">
-          <Skeleton className="h-9 w-24" />
+          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+            <ChevronLeft className="h-4 w-4" /> Previous
+          </Button>
           <Skeleton className="h-9 w-9" />
           <Skeleton className="h-9 w-9" />
-          <Skeleton className="h-9 w-24" />
+          <Button disabled variant="outline" size="sm" className="h-9 w-24 gap-1">
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/manageRiddles/ManageRiddlesSkeleton.tsx
+++ b/frontend/src/components/manageRiddles/ManageRiddlesSkeleton.tsx
@@ -1,4 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { Pencil, Puzzle, Trash2 } from "lucide-react";
 
 type ManageRiddlesSkeletonProps = {
   readonly count?: number;
@@ -17,10 +19,16 @@ export default function ManageRiddlesSkeleton({
         >
           <div className="bg-muted/30 p-6 pb-4">
             <div className="flex items-start justify-between gap-2">
-              <Skeleton className="h-9 w-9 rounded-lg" />
+              <div className="p-2 bg-primary/10 rounded-lg">
+                <Puzzle className="w-5 h-5 text-primary" />
+              </div>
               <div className="flex items-center gap-2">
-                <Skeleton className="h-8 w-8 rounded-md" />
-                <Skeleton className="h-8 w-8 rounded-md" />
+                <Button disabled variant="ghost" size="icon" className="h-8 w-8">
+                  <Pencil className="w-4 h-4" />
+                </Button>
+                <Button disabled variant="ghost" size="icon" className="h-8 w-8 text-destructive">
+                  <Trash2 className="w-4 h-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -10,7 +10,7 @@ import { DropdownMenuTrigger } from "../components/ui/dropdown-menu";
 import { Panel, type ImperativePanelGroupHandle, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import MonacoEditor from "@monaco-editor/react";
 import { submitToJudge0 } from '@/api/Judge0API';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import type { Question } from '@/types/questions/QuestionPagination.type';
 import Loader from '../components/helpers/Loader';
 import { useAnalytics } from '@/hooks/useAnalytics';
@@ -25,9 +25,11 @@ import ConfirmCodeReset from '@/components/helpers/ConfirmCodeReset';
 import { useUser } from '@/context/UserContext';
 import type { SubmissionType } from '@/types/submissions/SubmissionType.type'
 import ConsoleOutput from '@/components/codingPage/ConsoleOutput';
+import { CompetitionTimer } from '@/components/codingPage/CompetitionTimer';
 import type { AlgoTimeSession } from '@/types/algoTime/AlgoTime.type';
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { TimesUpDialog } from '@/components/codingPage/TimesUpDialog';
 import { getAllSubmissions } from '@/api/SubmissionAPI';
 import { useCountdown } from '@/hooks/useCountdown'
 
@@ -60,6 +62,7 @@ const CodingView = () => {
   } = useAnalytics()
 
   const { user } = useUser();
+  const navigate = useNavigate();
 
   const [theme, setTheme] = useState<string>(
     localStorage.getItem("theme") === "dark" ? "vs-dark" : "vs"
@@ -71,6 +74,24 @@ const CodingView = () => {
   const hasSubmittedRef = useRef(false);
   const remainingMs = useCountdown(event?.event_end_date)
   const isExpired = remainingMs === 0
+  const [redirectCountdown, setRedirectCountdown] = useState<number | null>(null)
+
+  // Show time's up dialog and redirect after 5 seconds
+  useEffect(() => {
+    if (isExpired && event) {
+      setRedirectCountdown(5)
+    }
+  }, [isExpired, event])
+
+  useEffect(() => {
+    if (redirectCountdown === null) return
+    if (redirectCountdown === 0) {
+      navigate('/app/home')
+      return
+    }
+    const id = setTimeout(() => setRedirectCountdown(c => (c ?? 1) - 1), 1000)
+    return () => clearTimeout(id)
+  }, [redirectCountdown, navigate])
 
 
 
@@ -362,43 +383,6 @@ const CodingView = () => {
   const mainPanelGroup = React.useRef<ImperativePanelGroupHandle>(null)
   const codePanelGroup = React.useRef<ImperativePanelGroupHandle>(null)
 
-  // Replace just the formattedTime display span with this component:
-
-  const CompetitionTimer = ({ remainingMs }: { remainingMs: number | null }) => {
-    if (remainingMs === null) return null
-
-    const isExpired = remainingMs === 0
-    const isWarning = remainingMs < 5 * 60 * 1000
-    const isUrgent = remainingMs < 60 * 1000
-
-    const totalSeconds = Math.floor(remainingMs / 1000)
-    const h = Math.floor(totalSeconds / 3600)
-    const m = Math.floor((totalSeconds % 3600) / 60)
-    const s = totalSeconds % 60
-    const display = h > 0
-      ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-      : `${m}:${String(s).padStart(2, '0')}`
-
-    return (
-      <div className={`
-      flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-mono font-medium tabular-nums
-      transition-colors duration-500
-      ${isExpired || isUrgent
-          ? 'bg-destructive/10 border-destructive/30 text-destructive'
-          : isWarning
-            ? 'bg-amber-500/10 border-amber-500/30 text-amber-600 dark:text-amber-400'
-            : 'bg-muted border-border text-muted-foreground'
-        }
-    `}>
-        <span className={`w-1.5 h-1.5 rounded-full ${isExpired ? 'bg-destructive' :
-          isUrgent ? 'bg-destructive animate-pulse' :
-            isWarning ? 'bg-amber-500 animate-pulse' :
-              'bg-emerald-500'
-          }`} />
-        {isExpired ? "Time's up" : display}
-      </div>
-    )
-  }
 
   useLayoutEffect(() => {
     let mainPanelSize: number[], codePanelSize: number[]
@@ -506,6 +490,10 @@ const CodingView = () => {
     >
       {/* Loading modal */}
       <Loader isOpen={isLoading} msg={loadingMsg} />
+
+      {/* Time's up dialog */}
+      <TimesUpDialog redirectCountdown={redirectCountdown} />
+
       <ConfirmCodeReset isOpen={clearingCode} setClose={() => setClearingCode(false)}
         setReset={() => setConfirmClearingCode(true)} setNoReset={() => setConfirmClearingCode(false)}
       />

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -427,13 +427,15 @@ const CodingView = () => {
   if (isLoading) {
     return (
       <div className="px-2 min-h-[calc(90vh)] min-w-[calc(100vw-var(--sidebar-width)-0.05rem)] flex flex-col gap-2">
-        {/* Submit button row */}
+        {/* Submit button row — static, always visible */}
         <div className="flex justify-center mb-2">
-          <Skeleton className="h-9 w-28 rounded-md" />
+          <Button disabled>
+            <CloudUpload size={16} />Submit
+          </Button>
         </div>
         {/* Main panels */}
         <div className="flex gap-2 flex-1">
-          {/* Description panel */}
+          {/* Description panel — content is dynamic */}
           <div className="flex-1 rounded-md border p-4 flex flex-col gap-3">
             <Skeleton className="h-6 w-48" />
             <Skeleton className="h-4 w-full" />
@@ -447,29 +449,46 @@ const CodingView = () => {
           <div className="flex-1 flex flex-col gap-2">
             {/* Code panel */}
             <div className="flex-[65] rounded-md border flex flex-col">
+              {/* Header — label and action buttons are static */}
               <div className="h-10 bg-muted border-b px-4 flex items-center justify-between">
-                <Skeleton className="h-4 w-12" />
+                <span className="text-lg font-medium">Code</span>
                 <div className="flex gap-1">
-                  {Array.from({ length: 4 }).map((_, i) => (
-                    <Skeleton key={i} className="h-7 w-7 rounded-full" />
-                  ))}
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <Play size={24} strokeWidth={2.5} />
+                  </Button>
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <RotateCcw size={22} strokeWidth={2} />
+                  </Button>
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <Maximize2 size={22} />
+                  </Button>
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <ChevronUp size={22} />
+                  </Button>
                 </div>
               </div>
+              {/* Language selector — dynamic, loaded from API */}
               <div className="h-10 border-b px-2 flex items-center">
                 <Skeleton className="h-6 w-24 rounded-md" />
               </div>
+              {/* Editor body — dynamic (preset code) */}
               <Skeleton className="flex-1 h-64 rounded-none" />
             </div>
             {/* Output panel */}
             <div className="flex-[35] rounded-md border flex flex-col">
+              {/* Header — label and action buttons are static */}
               <div className="h-10 bg-muted border-b px-4 flex items-center justify-between">
-                <Skeleton className="h-4 w-16" />
+                <span className="text-lg font-medium">Output</span>
                 <div className="flex gap-1">
-                  {Array.from({ length: 2 }).map((_, i) => (
-                    <Skeleton key={i} className="h-7 w-7 rounded-full" />
-                  ))}
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <Maximize2 size={22} />
+                  </Button>
+                  <Button disabled className="w-7 shadow-none bg-muted rounded-full">
+                    <ChevronDown size={22} />
+                  </Button>
                 </div>
               </div>
+              {/* Output content — dynamic */}
               <div className="p-2.5 flex flex-col gap-2">
                 <Skeleton className="h-4 w-full" />
                 <Skeleton className="h-4 w-3/4" />

--- a/frontend/src/views/admin/AdminDashboardPage.tsx
+++ b/frontend/src/views/admin/AdminDashboardPage.tsx
@@ -197,24 +197,22 @@ export function AdminDashboard() {
             <div
               className={`flex justify-between items-center gap-2 mt-6 px-6 motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-out ${sectionEnterClass}`}
             >
-              <div className="flex items-center">
-                <Tabs value={activeTab} onValueChange={handleTabChange}>
-                  <TabsList>
-                    <TabsTrigger
-                      value="algotime"
-                      className="cursor-pointer rounded-md font-semibold text-muted-foreground p-4 transition-all duration-200 relative hover:text-primary data-[state=active]:text-primary"
-                    >
-                      Algotime
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="competitions"
-                      className="cursor-pointer rounded-md font-semibold text-muted-foreground p-3 transition-all duration-200 relative hover:text-primary data-[state=active]:text-primary"
-                    >
-                      Competitions
-                    </TabsTrigger>
-                  </TabsList>
-                </Tabs>
-              </div>
+              <Tabs value={activeTab} onValueChange={handleTabChange}>
+                <TabsList className="p-0 h-9 bg-transparent border rounded-lg overflow-hidden gap-0">
+                  <TabsTrigger
+                    value="algotime"
+                    className="h-full rounded-none px-5 text-sm font-medium border-r data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
+                  >
+                    AlgoTime
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="competitions"
+                    className="h-full rounded-none px-5 text-sm font-medium data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
+                  >
+                    Competitions
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
 
               <div>
                 <Select value={timeRange} onValueChange={handleTimeRangeChange}>

--- a/frontend/src/views/admin/AdminDashboardPage.tsx
+++ b/frontend/src/views/admin/AdminDashboardPage.tsx
@@ -197,22 +197,24 @@ export function AdminDashboard() {
             <div
               className={`flex justify-between items-center gap-2 mt-6 px-6 motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-out ${sectionEnterClass}`}
             >
-              <Tabs value={activeTab} onValueChange={handleTabChange}>
-                <TabsList className="p-0 h-9 bg-transparent border rounded-lg overflow-hidden gap-0">
-                  <TabsTrigger
-                    value="algotime"
-                    className="h-full rounded-none px-5 text-sm font-medium border-r data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
-                  >
-                    AlgoTime
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="competitions"
-                    className="h-full rounded-none px-5 text-sm font-medium data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-none"
-                  >
-                    Competitions
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
+              <div className="flex items-center">
+                <Tabs value={activeTab} onValueChange={handleTabChange}>
+                  <TabsList>
+                    <TabsTrigger
+                      value="algotime"
+                      className="cursor-pointer rounded-md font-semibold text-muted-foreground p-4 transition-all duration-200 relative hover:text-primary data-[state=active]:text-primary"
+                    >
+                      Algotime
+                    </TabsTrigger>
+                    <TabsTrigger
+                      value="competitions"
+                      className="cursor-pointer rounded-md font-semibold text-muted-foreground p-3 transition-all duration-200 relative hover:text-primary data-[state=active]:text-primary"
+                    >
+                      Competitions
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              </div>
 
               <div>
                 <Select value={timeRange} onValueChange={handleTimeRangeChange}>

--- a/frontend/src/views/admin/ManageCompetitionsPage.tsx
+++ b/frontend/src/views/admin/ManageCompetitionsPage.tsx
@@ -299,7 +299,7 @@ const ManageCompetitions = () => {
       </div>
 
       {loading ? (
-        <ManageCompetitionsSkeleton />
+        <ManageCompetitionsSkeleton isOwner={user?.accountType.toLowerCase() === "owner"} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {/* Create Button Card */}

--- a/frontend/tests/CodingView.test.tsx
+++ b/frontend/tests/CodingView.test.tsx
@@ -105,6 +105,7 @@ jest.mock('sonner', () => ({
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useLocation: jest.fn(),
+    useNavigate: jest.fn(() => jest.fn()),
 }))
 
 let capturedOnRiddleSolved: (() => void) | undefined

--- a/frontend/tests/CompetitionTimer.test.tsx
+++ b/frontend/tests/CompetitionTimer.test.tsx
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { CompetitionTimer } from '../src/components/codingPage/CompetitionTimer'
+
+describe('CompetitionTimer', () => {
+    it('renders nothing when remainingMs is null', () => {
+        const { container } = render(<CompetitionTimer remainingMs={null} />)
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('shows formatted time in mm:ss when under 1 hour', () => {
+        render(<CompetitionTimer remainingMs={5 * 60 * 1000 + 30 * 1000} />) // 5:30
+        expect(screen.getByText('5:30')).toBeInTheDocument()
+    })
+
+    it('shows formatted time in hh:mm:ss when 1 hour or more', () => {
+        render(<CompetitionTimer remainingMs={2 * 3600 * 1000 + 3 * 60 * 1000 + 15 * 1000} />) // 2:03:15
+        expect(screen.getByText('2:03:15')).toBeInTheDocument()
+    })
+
+    it("shows \"Time's up\" when remainingMs is 0", () => {
+        render(<CompetitionTimer remainingMs={0} />)
+        expect(screen.getByText("Time's up")).toBeInTheDocument()
+    })
+
+    it('applies destructive styles when expired', () => {
+        const { container } = render(<CompetitionTimer remainingMs={0} />)
+        expect(container.firstChild).toHaveClass('bg-destructive/10')
+    })
+
+    it('applies amber warning styles when under 5 minutes', () => {
+        const { container } = render(<CompetitionTimer remainingMs={3 * 60 * 1000} />) // 3 min
+        expect(container.firstChild).toHaveClass('bg-amber-500/10')
+    })
+
+    it('applies animate-pulse when under 1 minute and not expired', () => {
+        const { container } = render(<CompetitionTimer remainingMs={30 * 1000} />) // 30s
+        expect(container.firstChild).toHaveClass('animate-pulse')
+    })
+
+    it('does not apply animate-pulse when over 1 minute', () => {
+        const { container } = render(<CompetitionTimer remainingMs={2 * 60 * 1000} />) // 2 min
+        expect(container.firstChild).not.toHaveClass('animate-pulse')
+    })
+
+    it('does not apply animate-pulse when expired', () => {
+        const { container } = render(<CompetitionTimer remainingMs={0} />)
+        expect(container.firstChild).not.toHaveClass('animate-pulse')
+    })
+
+    it('applies default muted styles when plenty of time remains', () => {
+        const { container } = render(<CompetitionTimer remainingMs={60 * 60 * 1000} />) // 1 hour
+        expect(container.firstChild).toHaveClass('bg-muted')
+    })
+})

--- a/frontend/tests/TimesUpDialog.test.tsx
+++ b/frontend/tests/TimesUpDialog.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { TimesUpDialog } from '../src/components/codingPage/TimesUpDialog'
+
+jest.mock('../src/components/ui/dialog', () => ({
+    Dialog: ({ open, children }: any) => open ? <div data-testid="dialog">{children}</div> : null,
+    DialogContent: ({ children }: any) => <div data-testid="dialog-content">{children}</div>,
+    DialogTitle: ({ children }: any) => <h2 data-testid="dialog-title">{children}</h2>,
+}))
+
+describe('TimesUpDialog', () => {
+    it('renders nothing when redirectCountdown is null', () => {
+        render(<TimesUpDialog redirectCountdown={null} />)
+        expect(screen.queryByTestId('dialog')).not.toBeInTheDocument()
+    })
+
+    it('renders the dialog when redirectCountdown is a number', () => {
+        render(<TimesUpDialog redirectCountdown={5} />)
+        expect(screen.getByTestId('dialog')).toBeInTheDocument()
+    })
+
+    it('shows the Time\'s Up title', () => {
+        render(<TimesUpDialog redirectCountdown={3} />)
+        expect(screen.getByTestId('dialog-title')).toHaveTextContent("Time's Up!")
+    })
+
+    it('shows the correct countdown value', () => {
+        render(<TimesUpDialog redirectCountdown={4} />)
+        expect(screen.getByText('4s')).toBeInTheDocument()
+    })
+
+    it('shows countdown of 0', () => {
+        render(<TimesUpDialog redirectCountdown={0} />)
+        expect(screen.getByText('0s')).toBeInTheDocument()
+    })
+
+    it('shows the participation message', () => {
+        render(<TimesUpDialog redirectCountdown={5} />)
+        expect(screen.getByText(/thanks for participating/i)).toBeInTheDocument()
+    })
+
+    it('shows the redirect message', () => {
+        render(<TimesUpDialog redirectCountdown={5} />)
+        expect(screen.getByText(/redirecting you to the home page/i)).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
## 📝 Description

> This PR fixes skeleton loading states across the app to keep static UI elements always visible during data
   fetches, and improves the competition coding experience by redirecting users to the home page when time
  runs out. 

## 🔧 Changes Made

- Updated all skeleton components (ManageCompetitionsSkeleton,  CompetitionsPageSkeleton,
 SubmissionSkeleton.....) to keep static elements visible like buttons, icons, column headers  and only skeletonize dynamically fetched content
 - Updated CodingView to show a TimesUpDialog with a countdown redirect to homepage when competition ends, add pulsing animation to the timer under 1 minute
 - Extracted CompetitionTimer and TimesUpDialog into their own component files for separation of concerns

## 🎯 Related Issues

Closes #425
Closes #426 

## ✅ Checklist

Before requesting review, confirm the following:

 - [ ] My code follows the project’s style guidelines
 - [ ] I’ve performed a self-review of my own code
 - [ ] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [ ]  I’ve added or updated tests if applicable
 - [ ] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)
<img width="1467" height="759" alt="Screenshot 2026-04-01 at 11 45 02 AM" src="https://github.com/user-attachments/assets/ef6bf083-cc7b-48c2-a7b6-f3c9941c55ca" />
<img width="715" height="545" alt="Screenshot 2026-03-31 at 3 01 45 PM" src="https://github.com/user-attachments/assets/6e26f81c-a8ed-4bd2-98af-e221b6fefc6f" />
<img width="1020" height="505" alt="image" src="https://github.com/user-attachments/assets/2d4fbdec-0670-493c-ac16-bab11f05e464" />
<img width="790" height="403" alt="Screenshot 2026-03-31 at 2 33 13 PM" src="https://github.com/user-attachments/assets/e0e97e39-45b2-4628-8fcc-e5d947940192" />
<img width="652" height="544" alt="Screenshot 2026-03-31 at 1 17 09 PM" src="https://github.com/user-attachments/assets/4b31ee63-bc28-45ab-a599-6fea673d5866" />
<img width="541" height="429" alt="Screenshot 2026-03-31 at 2 05 40 PM" src="https://github.com/user-attachments/assets/2233b249-be98-44cc-8158-3dfbc133a67d" />



## 💬 Additional Notes

none
