### PR TITLE
Make Timer and TimeUp dialog components generic for competition and algotime

### DIFF
--- a/frontend/src/components/codingPage/SessionTimer.tsx
+++ b/frontend/src/components/codingPage/SessionTimer.tsx
@@ -1,8 +1,8 @@
-interface CompetitionTimerProps {
+interface SessionTimerProps {
   remainingMs: number | null;
 }
 
-export function CompetitionTimer({ remainingMs }: CompetitionTimerProps) {
+export function SessionTimer({ remainingMs }: SessionTimerProps) {
   if (remainingMs === null) return null
 
   const isExpired = remainingMs === 0

--- a/frontend/src/components/codingPage/SessionTimer.tsx
+++ b/frontend/src/components/codingPage/SessionTimer.tsx
@@ -1,8 +1,8 @@
 interface SessionTimerProps {
-  remainingMs: number | null;
+  readonly remainingMs: number | null;
 }
 
-export function SessionTimer({ remainingMs }: SessionTimerProps) {
+export function SessionTimer({ remainingMs }: Readonly<SessionTimerProps>) {
   if (remainingMs === null) return null
 
   const isExpired = remainingMs === 0
@@ -17,23 +17,28 @@ export function SessionTimer({ remainingMs }: SessionTimerProps) {
     ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
     : `${m}:${String(s).padStart(2, '0')}`
 
+  const dotClass = isExpired
+    ? 'bg-destructive'
+    : isUrgent
+      ? 'bg-destructive animate-pulse'
+      : isWarning
+        ? 'bg-amber-500 animate-pulse'
+        : 'bg-emerald-500'
+
+  const containerClass = isExpired || isUrgent
+    ? 'bg-destructive/10 border-destructive/30 text-destructive'
+    : isWarning
+      ? 'bg-amber-500/10 border-amber-500/30 text-amber-600 dark:text-amber-400'
+      : 'bg-muted border-border text-muted-foreground'
+
   return (
     <div className={`
       flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-mono font-medium tabular-nums
       transition-colors duration-500
       ${isUrgent && !isExpired ? 'animate-pulse' : ''}
-      ${isExpired || isUrgent
-        ? 'bg-destructive/10 border-destructive/30 text-destructive'
-        : isWarning
-          ? 'bg-amber-500/10 border-amber-500/30 text-amber-600 dark:text-amber-400'
-          : 'bg-muted border-border text-muted-foreground'
-      }
+      ${containerClass}
     `}>
-      <span className={`w-1.5 h-1.5 rounded-full ${isExpired ? 'bg-destructive' :
-        isUrgent ? 'bg-destructive animate-pulse' :
-          isWarning ? 'bg-amber-500 animate-pulse' :
-            'bg-emerald-500'
-        }`} />
+      <span className={`w-1.5 h-1.5 rounded-full ${dotClass}`} />
       {isExpired ? "Time's up" : display}
     </div>
   )

--- a/frontend/src/components/codingPage/TimesUpDialog.tsx
+++ b/frontend/src/components/codingPage/TimesUpDialog.tsx
@@ -15,7 +15,7 @@ export function TimesUpDialog({ redirectCountdown }: TimesUpDialogProps) {
           </div>
           <DialogTitle className="text-xl font-semibold">Time's Up!</DialogTitle>
           <p className="text-muted-foreground text-sm">
-            The competition has ended. Thanks for participating!
+            Your session has ended. Thanks for participating!
           </p>
           <p className="text-sm">
             Redirecting you to the home page in{' '}

--- a/frontend/src/views/CodingView.tsx
+++ b/frontend/src/views/CodingView.tsx
@@ -25,7 +25,7 @@ import ConfirmCodeReset from '@/components/helpers/ConfirmCodeReset';
 import { useUser } from '@/context/UserContext';
 import type { SubmissionType } from '@/types/submissions/SubmissionType.type'
 import ConsoleOutput from '@/components/codingPage/ConsoleOutput';
-import { CompetitionTimer } from '@/components/codingPage/CompetitionTimer';
+import { SessionTimer } from '@/components/codingPage/SessionTimer';
 import type { AlgoTimeSession } from '@/types/algoTime/AlgoTime.type';
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -541,7 +541,7 @@ const CodingView = () => {
             <Button onClick={submitCode} data-testid="submit-btn" disabled={isExpired}>
               <CloudUpload size={16} />Submit
             </Button>
-            <CompetitionTimer remainingMs={remainingMs} />
+            <SessionTimer remainingMs={remainingMs} />
           </div>
           {questionsInstances.length > 1 && (
             <div className='absolute right-0'>

--- a/frontend/tests/SessionTimer.test.tsx
+++ b/frontend/tests/SessionTimer.test.tsx
@@ -1,55 +1,55 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
-import { CompetitionTimer } from '../src/components/codingPage/CompetitionTimer'
+import { SessionTimer } from '../src/components/codingPage/SessionTimer'
 
-describe('CompetitionTimer', () => {
+describe('SessionTimer', () => {
     it('renders nothing when remainingMs is null', () => {
-        const { container } = render(<CompetitionTimer remainingMs={null} />)
+        const { container } = render(<SessionTimer remainingMs={null} />)
         expect(container).toBeEmptyDOMElement()
     })
 
     it('shows formatted time in mm:ss when under 1 hour', () => {
-        render(<CompetitionTimer remainingMs={5 * 60 * 1000 + 30 * 1000} />) // 5:30
+        render(<SessionTimer remainingMs={5 * 60 * 1000 + 30 * 1000} />) // 5:30
         expect(screen.getByText('5:30')).toBeInTheDocument()
     })
 
     it('shows formatted time in hh:mm:ss when 1 hour or more', () => {
-        render(<CompetitionTimer remainingMs={2 * 3600 * 1000 + 3 * 60 * 1000 + 15 * 1000} />) // 2:03:15
+        render(<SessionTimer remainingMs={2 * 3600 * 1000 + 3 * 60 * 1000 + 15 * 1000} />) // 2:03:15
         expect(screen.getByText('2:03:15')).toBeInTheDocument()
     })
 
     it("shows \"Time's up\" when remainingMs is 0", () => {
-        render(<CompetitionTimer remainingMs={0} />)
+        render(<SessionTimer remainingMs={0} />)
         expect(screen.getByText("Time's up")).toBeInTheDocument()
     })
 
     it('applies destructive styles when expired', () => {
-        const { container } = render(<CompetitionTimer remainingMs={0} />)
+        const { container } = render(<SessionTimer remainingMs={0} />)
         expect(container.firstChild).toHaveClass('bg-destructive/10')
     })
 
     it('applies amber warning styles when under 5 minutes', () => {
-        const { container } = render(<CompetitionTimer remainingMs={3 * 60 * 1000} />) // 3 min
+        const { container } = render(<SessionTimer remainingMs={3 * 60 * 1000} />) // 3 min
         expect(container.firstChild).toHaveClass('bg-amber-500/10')
     })
 
     it('applies animate-pulse when under 1 minute and not expired', () => {
-        const { container } = render(<CompetitionTimer remainingMs={30 * 1000} />) // 30s
+        const { container } = render(<SessionTimer remainingMs={30 * 1000} />) // 30s
         expect(container.firstChild).toHaveClass('animate-pulse')
     })
 
     it('does not apply animate-pulse when over 1 minute', () => {
-        const { container } = render(<CompetitionTimer remainingMs={2 * 60 * 1000} />) // 2 min
+        const { container } = render(<SessionTimer remainingMs={2 * 60 * 1000} />) // 2 min
         expect(container.firstChild).not.toHaveClass('animate-pulse')
     })
 
     it('does not apply animate-pulse when expired', () => {
-        const { container } = render(<CompetitionTimer remainingMs={0} />)
+        const { container } = render(<SessionTimer remainingMs={0} />)
         expect(container.firstChild).not.toHaveClass('animate-pulse')
     })
 
     it('applies default muted styles when plenty of time remains', () => {
-        const { container } = render(<CompetitionTimer remainingMs={60 * 60 * 1000} />) // 1 hour
+        const { container } = render(<SessionTimer remainingMs={60 * 60 * 1000} />) // 1 hour
         expect(container.firstChild).toHaveClass('bg-muted')
     })
 })


### PR DESCRIPTION
## 📝 Description

> After  investigating, I found that the timer and "Time's Up" dialog were already being used in the coding view for both competition and AlgoTime sessions but hey just had competition-specific naming and content. This PR makes them generic so they work correctly for any session type without misleading labels.

## 🔧 Changes Made

- Renamed `CompetitionTimer.tsx `→ `SessionTimer.tsx` and updated the component/interface names accordingly
- Updated `TimesUpDialog.tsx` body text to be session-agnostic
- Updated `CodingView.tsx `to import and use SessionTimer instead of CompetitionTimer
- Renamed `CompetitionTimer.test.tsx `→ `SessionTimer.test.tsx `and updated all imports and references to match the new component name

## 🎯 Related Issues

Closes #429 

## ✅ Checklist

Before requesting review, confirm the following:

 - [x] My code follows the project’s style guidelines
 - [x] I’ve performed a self-review of my own code
 - [x] I’ve commented my code where necessary OR removed unnecessary commented out code
 - [x]  I’ve added or updated tests if applicable
 - [x] New and existing tests pass locally
 - [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)

none

## 💬 Additional Notes

none
