### PR TITLE
436 bugs   ownerdashboard

### DIFF
--- a/backend/src/endpoints/admin_dashboard_api.py
+++ b/backend/src/endpoints/admin_dashboard_api.py
@@ -6,7 +6,7 @@ from models.schema import (
     AlgoTimeSession, QuestionInstance, UserQuestionInstance, Submission, UserSession
 )
 from database_operations.database import get_db
-from endpoints.authentification_api import role_required
+from endpoints.authentification_api import roles_required
 from pydantic import BaseModel
 from typing import List, Optional, Literal
 from datetime import datetime, timezone, timedelta
@@ -157,7 +157,7 @@ def get_chart_colors():
 @admin_dashboard_router.get("/overview", response_model=DashboardOverviewResponse)
 async def get_dashboard_overview(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))]
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))]
 ):
     """
     Get dashboard overview with 2 most recent items for each category.
@@ -264,7 +264,7 @@ async def get_dashboard_overview(
 @admin_dashboard_router.get("/stats/new-accounts", response_model=NewAccountsStatsResponse)
 async def get_new_accounts_stats(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))],
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))],
     time_range: Annotated[
             Literal["7days", "30days", "3months"],
             Query()
@@ -318,7 +318,7 @@ async def get_new_accounts_stats(
 @admin_dashboard_router.get("/stats/questions-solved", response_model=List[QuestionsSolvedItem])
 async def get_questions_solved_stats(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))],
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))],
     time_range: Annotated[
             Literal["7days", "30days", "3months"],
             Query()
@@ -371,7 +371,7 @@ async def get_questions_solved_stats(
 @admin_dashboard_router.get("/stats/time-to-solve", response_model=List[TimeToSolveItem])
 async def get_time_to_solve_stats(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))],
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))],
     time_range: Annotated[
             Literal["7days", "30days", "3months"],
             Query()
@@ -429,7 +429,7 @@ async def get_time_to_solve_stats(
 @admin_dashboard_router.get("/stats/logins", response_model=List[LoginsDataPoint])
 async def get_logins_stats(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))],
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))],
     time_range: Annotated[
             Literal["7days", "30days", "3months"],
             Query()
@@ -516,7 +516,7 @@ async def get_logins_stats(
 @admin_dashboard_router.get("/stats/participation", response_model=List[ParticipationDataPoint])
 async def get_participation_stats(
     db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[dict, Depends(role_required("admin"))],
+    current_user: Annotated[dict, Depends( roles_required("owner", "admin"))],
     time_range: Annotated[
             Literal["7days", "30days", "3months"],
             Query()

--- a/backend/src/endpoints/admin_dashboard_api.py
+++ b/backend/src/endpoints/admin_dashboard_api.py
@@ -7,7 +7,6 @@ from models.schema import (
     AlgoTimeSession, QuestionInstance, UserQuestionInstance, Submission, UserSession
 )
 from database_operations.database import get_db
-from endpoints.authentification_api import roles_required
 from endpoints.authentification_api import get_current_user
 from endpoints.long_term_statistics_api import get_long_term_statistics_summary
 from pydantic import BaseModel

--- a/backend/src/endpoints/authentification_api.py
+++ b/backend/src/endpoints/authentification_api.py
@@ -189,14 +189,13 @@ UNAUTHORIZED_RESPONSE = {
 }
 
 
-def role_required(required_role: str):
+def roles_required(*required_roles: str):
     def role_checker(current_user: Annotated[dict, Depends(get_current_user)]):
-        if current_user.get("role") != required_role:
+        if current_user.get("role") not in required_roles:
             logger.warning(
-                f"Access Forbidden: User {current_user.get('sub')} attempted to access role '{required_role}' endpoint.")
+                f"Access Forbidden: User {current_user.get('sub')} attempted to access endpoint requiring roles {required_roles}.")
             raise HTTPException(status_code=403, detail="Forbidden")
         return current_user
-
     return role_checker
 
 
@@ -548,7 +547,7 @@ async def logout(
 @auth_router.get("/admin/dashboard", responses=UNAUTHORIZED_RESPONSE)
 async def admin_dashboard(
         db: Annotated[Session, Depends(get_db)],
-        current_user: Annotated[dict, Depends(role_required("admin"))]
+        current_user: Annotated[dict, Depends(roles_required("admin"))]
 ):
     user_email = current_user.get("sub", "N/A")
     logger.info(f"Admin dashboard accessed successfully by user: {user_email}")

--- a/backend/src/endpoints/authentification_api.py
+++ b/backend/src/endpoints/authentification_api.py
@@ -319,7 +319,7 @@ GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "your-google-client-id")
 
 
 @auth_router.post("/google-auth", responses=UNAUTHORIZED_RESPONSE)
-async def google_login(request: GoogleAuthRequest, db: Annotated[Session, Depends(get_db)]):
+async def google_login(request: GoogleAuthRequest,response: Response, db: Annotated[Session, Depends(get_db)]):
     logger.info("Attempting Google OAuth login.")
     try:
         idinfo = id_token.verify_oauth2_token(request.credential, grequests.Request(), GOOGLE_CLIENT_ID)
@@ -396,6 +396,7 @@ async def google_login(request: GoogleAuthRequest, db: Annotated[Session, Depend
         )
 
         token = create_access_token({"sub": user.email, "role": user.user_type, "id": user.user_id})
+        refresh_token = create_refresh_token({"sub": user.email})
 
         # Create a session record for tracking logins
         expires_at = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
@@ -407,6 +408,15 @@ async def google_login(request: GoogleAuthRequest, db: Annotated[Session, Depend
         )
         db.add(session)
         _commit_or_rollback(db)
+        
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            max_age=REFRESH_TOKEN_EXPIRE_DAYS * 24 * 3600,
+            samesite="none",
+            secure=True
+        )
 
         logger.info(f"SUCCESSFUL GOOGLE AUTH: User '{email}' logged in/authenticated. Role: {user.user_type}")
         return {"access_token": token}

--- a/frontend/cypress/e2e/dashboard.cy.ts
+++ b/frontend/cypress/e2e/dashboard.cy.ts
@@ -82,9 +82,6 @@ describe('Admin Dashboard', () => {
   });
 
   it('renders the main dashboard overview', () => {
-    // Check for the header
-    cy.get('h1').contains('Overview').should('be.visible');
-
     // Check that the default tab is active
     cy.contains('button', 'Algotime').should('have.attr', 'data-state', 'active');
 

--- a/frontend/src/components/forms/LogInForm.tsx
+++ b/frontend/src/components/forms/LogInForm.tsx
@@ -125,6 +125,15 @@ export function LoginForm({
 
         const decoded = jwtDecode<DecodedToken>(token);
 
+        const profile = await getProfile();
+        const prefs = await getUserPreferences(profile.id);
+
+        localStorage.setItem("theme", prefs.theme ?? "light");
+        if (prefs.theme === "dark") document.documentElement.classList.add("dark");
+
+        setUser(profile);
+
+
         trackLoginSuccess("google");
 
         // Identify the user so all future events are tied to them

--- a/frontend/src/components/helpers/HomePageBanner.tsx
+++ b/frontend/src/components/helpers/HomePageBanner.tsx
@@ -30,23 +30,23 @@ export default function HomePageBanner({ competitions }: Readonly<HomePageBanner
 
   const competitionData = useMemo(() => {
     const now = currentTime;
-    
+
     const activeCompetition = competitions.find(
       (c) => new Date(c.startDate) <= now && new Date(c.endDate) >= now
     );
-    
+
     if (activeCompetition) {
       return { competition: activeCompetition, status: "active" as const };
     }
-    
+
     const upcomingCompetitions = competitions
       .filter((c) => new Date(c.startDate) > now)
       .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
-    
+
     if (upcomingCompetitions.length > 0) {
       return { competition: upcomingCompetitions[0], status: "upcoming" as const };
     }
-    
+
     return null;
   }, [competitions, currentTime]);
 
@@ -102,7 +102,7 @@ export default function HomePageBanner({ competitions }: Readonly<HomePageBanner
         </p>
         <Button
           variant="outline"
-          className="rounded-lg font-semibold cursor-pointer text-primary hover:text-primary"
+          className="rounded-lg font-semibold cursor-pointer text-primary hover:text-primary bg-white hover:bg-white/90 border-white dark:text-primary dark:bg-white dark:hover:bg-white/90"
           onClick={() => {
             nav(`/app/comp/${competition.competitionTitle}`, {
               state: {
@@ -133,7 +133,7 @@ export default function HomePageBanner({ competitions }: Readonly<HomePageBanner
         {competition.competitionTitle}
       </h1>
       <p className="text-white text-lg mb-3">
-        Get ready! The competition starts on {new Date(competition.startDate).toLocaleDateString()} at {new Date(competition.startDate).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit',})}.
+        Get ready! The competition starts on {new Date(competition.startDate).toLocaleDateString()} at {new Date(competition.startDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', })}.
       </p>
     </div>
   );

--- a/frontend/src/views/admin/AdminDashboardPage.tsx
+++ b/frontend/src/views/admin/AdminDashboardPage.tsx
@@ -164,11 +164,7 @@ export function AdminDashboard() {
     <div className="flex flex-col w-full">
       {isRootDashboard ? (
         <div>
-          <div className="border-b">
-            <div className="flex justify-between items-center py-4 px-10">
-              <h1 className="text-base font-semibold text-primary">Overview</h1>
-            </div>
-          </div>
+
 
           {/* Management Cards Row */}
           <div
@@ -247,37 +243,37 @@ export function AdminDashboard() {
             <div
               className={`grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-4 mt-6 px-6 motion-safe:transition-all motion-safe:duration-500 motion-safe:ease-out ${sectionEnterClass}`}
             >
-                <StatsCard
-                  title="New Accounts"
-                  loading={statsLoading}
-                  contentReady={!statsLoading}
-                  value={newAccountStats.value}
-                  subtitle={newAccountStats.subtitle}
-                  description={newAccountStats.description}
+              <StatsCard
+                title="New Accounts"
+                loading={statsLoading}
+                contentReady={!statsLoading}
+                value={newAccountStats.value}
+                subtitle={newAccountStats.subtitle}
+                description={newAccountStats.description}
                 trend={newAccountStats.trend}
               />
-                <StatsCard
-                  title="Questions solved"
-                  contentReady={!statsLoading}
-                  dateSubtitle={getTimeRangeLabel(timeRange)}
-                >
+              <StatsCard
+                title="Questions solved"
+                contentReady={!statsLoading}
+                dateSubtitle={getTimeRangeLabel(timeRange)}
+              >
                 <QuestionsSolvedChart
                   key={`questions-${sharedChartAnimationKey}`}
                   data={questionsSolvedData}
                   loading={statsLoading}
                 />
               </StatsCard>
-                <StatsCard title="Avg. Question Solve Time" contentReady={!statsLoading}>
-                  <TimeToSolveChart
-                    key={`time-${sharedChartAnimationKey}`}
-                    data={timeToSolveData}
+              <StatsCard title="Avg. Question Solve Time" contentReady={!statsLoading}>
+                <TimeToSolveChart
+                  key={`time-${sharedChartAnimationKey}`}
+                  data={timeToSolveData}
                   loading={statsLoading}
                 />
               </StatsCard>
-                <StatsCard title="Number of logins" contentReady={!statsLoading}>
-                  <NumberOfLoginsChart
-                    key={`logins-${sharedChartAnimationKey}`}
-                    data={loginsData}
+              <StatsCard title="Number of logins" contentReady={!statsLoading}>
+                <NumberOfLoginsChart
+                  key={`logins-${sharedChartAnimationKey}`}
+                  data={loginsData}
                   loading={statsLoading}
                 />
               </StatsCard>

--- a/frontend/src/views/admin/ManageAlgotimeSessionsPage.tsx
+++ b/frontend/src/views/admin/ManageAlgotimeSessionsPage.tsx
@@ -287,6 +287,8 @@ export default function ManageAlgotimeSessionsPage() {
           {algotimesSessions.map((ATsession, index) => (
             (() => {
               const rowIndex = Math.floor(index / 4);
+              const status = getEventStatus(ATsession.startTime, ATsession.endTime);
+              const isCompleted = status === "Completed";
               const enterClass = cardsVisible
                 ? "translate-y-0"
                 : "translate-y-2 opacity-0";
@@ -301,17 +303,12 @@ export default function ManageAlgotimeSessionsPage() {
                 >
                   <div className="aspect-4/3 bg-gradient-to-br from-primary/10 via-primary/5 to-background flex items-center justify-center relative overflow-hidden p-6">
                     <div className="absolute top-3 right-3 z-20">
-                      {(() => {
-                        const status = getEventStatus(ATsession.startTime, ATsession.endTime);
-                        return (
-                          <span className={`text-xs font-medium px-2.5 py-1 rounded-full whitespace-nowrap shadow-sm ${getAdminStatusBadgeClasses(status)}`}>
-                            {status}
-                          </span>
-                        );
-                      })()}
+                      <span className={`text-xs font-medium px-2.5 py-1 rounded-full whitespace-nowrap shadow-sm ${getAdminStatusBadgeClasses(status)}`}>
+                        {status}
+                      </span>
                     </div>
                     <div className="relative z-10 text-center w-full">
-                      <div className="text-2xl md:text-3xl font-bold text-primary/80 break-words leading-tight">
+                      <div className={`text-2xl md:text-3xl font-bold break-words leading-tight ${isCompleted ? "text-muted-foreground" : "text-primary/80"}`}>
                         {ATsession.eventName || "no event"}
                       </div>
                     </div>
@@ -321,7 +318,7 @@ export default function ManageAlgotimeSessionsPage() {
                       <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
                         Date
                       </h4>
-                      <p className="font-medium text-sm line-clamp-3 leading-relaxed">
+                      <p className={`font-medium text-sm line-clamp-3 leading-relaxed ${isCompleted ? "text-muted-foreground/60" : ""}`}>
                         {formatEventDate(ATsession.startTime)}
                       </p>
                     </div>

--- a/frontend/src/views/admin/ManageCompetitionsPage.tsx
+++ b/frontend/src/views/admin/ManageCompetitionsPage.tsx
@@ -326,10 +326,8 @@ const ManageCompetitions = () => {
           {competitions.map((comp, index) => {
             const status = getEventStatus(comp.startDate, comp.endDate);
             const title = comp.competitionTitle || "Untitled Competition";
-            let opacityClass = "opacity-100";
-            if (status === "Completed") {
-              opacityClass = "opacity-75";
-            }
+            const isCompleted = status === "Completed";
+            const opacityClass = isCompleted ? "opacity-60 grayscale-[50%]" : "opacity-100";
             const rowIndex = Math.floor(index / 4);
             const enterClass = cardsVisible
               ? "translate-y-0"
@@ -354,7 +352,7 @@ const ManageCompetitions = () => {
                     </span>
                   </div>
                   <div className="relative z-10 text-center w-full">
-                    <div className="text-2xl md:text-3xl font-bold text-primary/80 break-words leading-tight">
+                    <div className={`text-2xl md:text-3xl font-bold break-words leading-tight ${isCompleted ? "text-muted-foreground" : "text-primary/80"}`}>
                       {title}
                     </div>
                   </div>
@@ -362,10 +360,10 @@ const ManageCompetitions = () => {
 
                 <CardContent className="p-4 space-y-3 flex-1 flex flex-col justify-between">
                   <div>
-                    <p className="text-xs text-muted-foreground mt-1">
+                    <p className={`text-xs mt-1 ${isCompleted ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
                       {comp.competitionLocation || "Location TBD"}
                     </p>
-                    <p className="text-xs text-muted-foreground mt-1">
+                    <p className={`text-xs mt-1 ${isCompleted ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
                       {formatEventDate(comp.startDate)}
                     </p>
                   </div>

--- a/frontend/tests/AdminDashboardPage.test.tsx
+++ b/frontend/tests/AdminDashboardPage.test.tsx
@@ -179,7 +179,7 @@ describe('AdminDashboard', () => {
     });
 
     // Check for header title
-    expect(screen.getByRole('heading', { name: /overview/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /platform metrics/i })).toBeInTheDocument();
   });
 
   it('renders stats, manage cards, and charts on the dashboard root route', async () => {

--- a/frontend/tests/ManageAccountsPage.test.tsx
+++ b/frontend/tests/ManageAccountsPage.test.tsx
@@ -36,6 +36,8 @@ jest.mock('../src/context/UserContext', () => ({
   useUser: jest.fn(() => ({ user: { id: 99, accountType: 'Owner' } })),
 }));
 
+
+
 // ─── Child component mocks ────────────────────────────────────────────────────
 
 jest.mock('../src/components/manageAccounts/ManageAccountsColumns', () => ({
@@ -96,8 +98,8 @@ describe('ManageAccountsPage Full Coverage', () => {
   });
 
   describe('Initial Render & Loading', () => {
-    it('displays loading skeleton initially', () => {
-      (getAccountsPage as jest.Mock).mockImplementation(() => new Promise(() => {}));
+    it('displays loading skeleton initially', async () => {
+      (getAccountsPage as jest.Mock).mockImplementation(() => new Promise(() => { })); // never resolves
       render(<ManageAccountsPage />);
       expect(screen.getByTestId('skeleton')).toBeInTheDocument();
     });


### PR DESCRIPTION
## 📝 Description
This PR fixes Google OAuth authentication, resolves admin dashboard access control, and improves UI styling for completed events across the manage pages.

## 🔧 Changes Made

**Added**
- `roles_required(*required_roles)` helper in `authentification_api.py` to support multi-role access control on protected routes
- Refresh token cookie generation in the `/google-auth` endpoint (was missing, causing session loss after Google sign-in)

**Updated**
- `handleGoogleSuccess` in `LoginForm.tsx` now calls `getProfile()`, `getUserPreferences()`, `setUser()`, and applies the saved theme — matching the behavior of the email/password login flow
- `setUser` added to the dependency array of `handleGoogleSuccess`
- All admin dashboard endpoints in `admin_dashboard_api.py` changed from `role_required("admin")` to `roles_required("owner", "admin")` so both roles can access statistics
- Completed competition cards in `ManageCompetitions.tsx` now render with `opacity-60 grayscale-[50%]` and muted text colors
- Completed algotime session cards in `ManageAlgotimeSessionsPage.tsx` apply the same grayed-out treatment; `status` is now computed once per card instead of inside a nested IIFE
- `HomePageBanner.tsx` Join Competition button pinned to white background with primary text in both light and dark mode

**Fixed**
- Google login requiring a page refresh before auth state was recognized — root cause was missing `setUser(profile)` call and absent refresh token cookie
- 403 Forbidden errors on all admin dashboard API calls — caused by a mismatch between the role stored in the JWT (`"owner"`) and the role checked by the route guard (`"admin"`)
- Join Competition button becoming unreadable in dark mode due to theme-dependent color variables

## 🎯 Related Issues
N/A

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I've performed a self-review of my own code
- [x] I've commented my code where necessary OR removed unnecessary commented out code
- [ ] I've added or updated tests if applicable
- [ ] New and existing tests pass locally
- [ ] Documentation has been updated (if relevant)

## 🖼️ Screenshots (Optional)
N/A

## 💬 Additional Notes
- The `token_blocklist` in `authentification_api.py` is currently an in-memory set — this will not persist across server restarts or scale across multiple instances. A Redis-backed blocklist should be considered as a follow-up.
- PostHog `identify` errors seen in logs are unrelated to this PR and should be addressed separately (wrong method name on the `Posthog` client object).